### PR TITLE
Run BPM matching as a foreground service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+
+    <uses-feature
+        android:name="android.hardware.sensor.gyroscope"
+        android:required="false" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -21,8 +32,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".service.BeatMatcherService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
+
+        <receiver
+            android:name=".service.BeatMatcherActionReceiver"
+            android:exported="false" />
+
     </application>
 
 </manifest>
-
-

--- a/app/src/main/java/com/hereliesaz/mademedance/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainActivity.kt
@@ -1,13 +1,19 @@
 package com.hereliesaz.mademedance
 
 import android.Manifest
+import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -18,18 +24,34 @@ import com.hereliesaz.mademedance.ui.theme.MadeMeDanceTheme
 
 class MainActivity : ComponentActivity() {
 
-    private lateinit var viewModel: MainViewModel
+    companion object {
+        const val EXTRA_OPEN_CLIPS = "open_clips"
+    }
 
-    private val requestPermissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
-            if (isGranted) {
-                viewModel.onPermissionGranted()
+    private lateinit var viewModel: MainViewModel
+    private var pendingStartAfterPermissions = false
+
+    private val requestAudioPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            viewModel.refreshPermissionState()
+            if (granted) maybeRequestNotificationPermission()
+            else pendingStartAfterPermissions = false
+        }
+
+    private val requestNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { _ ->
+            viewModel.refreshPermissionState()
+            if (pendingStartAfterPermissions && viewModel.hasAudioPermission.value) {
+                viewModel.startService()
             }
+            pendingStartAfterPermissions = false
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        val openClipsOnLaunch = intent?.getBooleanExtra(EXTRA_OPEN_CLIPS, false) == true
 
         setContent {
             MadeMeDanceTheme {
@@ -40,9 +62,18 @@ class MainActivity : ComponentActivity() {
                 val audio by vm.audioStatus.collectAsState()
                 val system by vm.systemStatus.collectAsState()
                 val hasPermission by vm.hasAudioPermission.collectAsState()
+                val isRunning by vm.isServiceRunning.collectAsState()
                 val movementBpm by vm.movementBpm.collectAsState()
                 val audioBpm by vm.audioBpm.collectAsState()
                 val navController = rememberNavController()
+
+                var navigatedToClips by remember { mutableStateOf(false) }
+                LaunchedEffect(openClipsOnLaunch) {
+                    if (openClipsOnLaunch && !navigatedToClips) {
+                        navController.navigate("clip_list")
+                        navigatedToClips = true
+                    }
+                }
 
                 NavHost(navController = navController, startDestination = "main") {
                     composable("main") {
@@ -51,11 +82,12 @@ class MainActivity : ComponentActivity() {
                             audioStatus = audio,
                             systemStatus = system,
                             hasAudioPermission = hasPermission,
+                            isServiceRunning = isRunning,
                             movementBpm = movementBpm,
                             audioBpm = audioBpm,
-                            onPermissionClick = {
-                                requestPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                            },
+                            onStartClick = { requestPermissionsAndStart() },
+                            onStopClick = { vm.stopService() },
+                            onPermissionClick = { requestPermissionsAndStart() },
                             onClipListClick = { navController.navigate("clip_list") }
                         )
                     }
@@ -70,22 +102,40 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+    }
+
     override fun onResume() {
         super.onResume()
         if (::viewModel.isInitialized) {
             viewModel.refreshPermissionState()
-            viewModel.startSensors()
-            if (viewModel.hasAudioPermission.value) {
-                viewModel.startAudioProcessing()
-            }
         }
     }
 
-    override fun onPause() {
-        super.onPause()
-        if (::viewModel.isInitialized) {
-            viewModel.stopSensors()
-            viewModel.stopAudioProcessing()
+    private fun requestPermissionsAndStart() {
+        if (!viewModel.hasAudioPermission.value) {
+            pendingStartAfterPermissions = true
+            requestAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+            return
+        }
+        if (!viewModel.hasNotificationPermission.value &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pendingStartAfterPermissions = true
+            requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            return
+        }
+        viewModel.startService()
+    }
+
+    private fun maybeRequestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            !viewModel.hasNotificationPermission.value) {
+            requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        } else if (pendingStartAfterPermissions) {
+            viewModel.startService()
+            pendingStartAfterPermissions = false
         }
     }
 }

--- a/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
@@ -4,164 +4,61 @@ import android.Manifest
 import android.app.Application
 import android.content.Context
 import android.content.pm.PackageManager
+import android.hardware.Sensor
 import android.hardware.SensorManager
-import android.os.Build
-import android.os.VibrationEffect
-import android.os.Vibrator
-import android.os.VibratorManager
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.viewModelScope
 import com.hereliesaz.mademedance.data.ClipRepository
-import com.hereliesaz.mademedance.sensor.MovementTracker
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
+import com.hereliesaz.mademedance.service.BeatMatcherService
+import com.hereliesaz.mademedance.service.BeatMatcherState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
-import java.io.File
-import java.io.IOException
-import kotlin.math.abs
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val _movementBpm = MutableStateFlow<Float?>(null)
-    val movementBpm: StateFlow<Float?> = _movementBpm.asStateFlow()
-
-    private val _audioBpm = MutableStateFlow<Float?>(null)
-    val audioBpm: StateFlow<Float?> = _audioBpm.asStateFlow()
-
-    private val _movementStatus = MutableStateFlow("Movement: -- BPM")
-    val movementStatus: StateFlow<String> = _movementStatus.asStateFlow()
-
-    private val _audioStatus = MutableStateFlow("Song: -- BPM")
-    val audioStatus: StateFlow<String> = _audioStatus.asStateFlow()
-
-    private val _systemStatus = MutableStateFlow("Listening...")
-    val systemStatus: StateFlow<String> = _systemStatus.asStateFlow()
+    val movementBpm: StateFlow<Float?> = BeatMatcherState.movementBpm
+    val audioBpm: StateFlow<Float?> = BeatMatcherState.audioBpm
+    val movementStatus: StateFlow<String> = BeatMatcherState.movementStatus
+    val audioStatus: StateFlow<String> = BeatMatcherState.audioStatus
+    val systemStatus: StateFlow<String> = BeatMatcherState.systemStatus
+    val isServiceRunning: StateFlow<Boolean> = BeatMatcherState.isRunning
 
     private val _hasAudioPermission = MutableStateFlow(false)
     val hasAudioPermission: StateFlow<Boolean> = _hasAudioPermission.asStateFlow()
 
-    private val sensorManager = application.getSystemService(Context.SENSOR_SERVICE) as SensorManager
-    val movementTracker = MovementTracker(sensorManager)
-
-    private val audioBpmDetector = AudioBpmDetector()
-    private var audioJob: Job? = null
+    private val _hasNotificationPermission = MutableStateFlow(false)
+    val hasNotificationPermission: StateFlow<Boolean> = _hasNotificationPermission.asStateFlow()
 
     val clipRepository = ClipRepository(application.getExternalFilesDir(null))
 
-    private val vibrator: Vibrator? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        (application.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as? VibratorManager)?.defaultVibrator
-    } else {
-        @Suppress("DEPRECATION")
-        application.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+    val hasGyroscope: Boolean = run {
+        val sm = application.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+        sm.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
     }
-
-    val hasGyroscope: Boolean = movementTracker.isAvailable
 
     init {
         refreshPermissionState()
-        if (!hasGyroscope) {
-            _movementStatus.value = "No gyroscope sensor"
-            _systemStatus.value = "This device lacks a gyroscope sensor."
-        }
-        viewModelScope.launch {
-            movementTracker.bpm.collect { bpm ->
-                if (bpm != null) {
-                    _movementBpm.value = bpm
-                    _movementStatus.value = "Movement: ${"%.1f".format(bpm)} BPM"
-                    checkForMatch()
-                }
-            }
-        }
     }
 
     fun refreshPermissionState() {
+        val ctx = getApplication<Application>()
         _hasAudioPermission.value = ContextCompat.checkSelfPermission(
-            getApplication(), Manifest.permission.RECORD_AUDIO
+            ctx, Manifest.permission.RECORD_AUDIO
         ) == PackageManager.PERMISSION_GRANTED
+        _hasNotificationPermission.value =
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                ContextCompat.checkSelfPermission(
+                    ctx, Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED
+            } else true
     }
 
-    fun onPermissionGranted() {
-        _hasAudioPermission.value = true
-        startAudioProcessing()
+    fun startService() {
+        BeatMatcherService.start(getApplication())
     }
 
-    fun startAudioProcessing() {
-        if (audioJob?.isActive == true) return
-        audioJob = viewModelScope.launch {
-            audioBpmDetector.start()
-            while (isActive) {
-                val bpm = audioBpmDetector.processAudio()
-                if (bpm != null) {
-                    _audioBpm.value = bpm
-                    _audioStatus.value = "Song: ${"%.1f".format(bpm)} BPM"
-                    checkForMatch()
-                }
-                delay(100)
-            }
-        }
-    }
-
-    fun stopAudioProcessing() {
-        audioJob?.cancel()
-        audioBpmDetector.stop()
-    }
-
-    fun startSensors() {
-        movementTracker.start()
-    }
-
-    fun stopSensors() {
-        movementTracker.stop()
-    }
-
-    private fun checkForMatch() {
-        val movementBpm = _movementBpm.value
-        val audioBpm = _audioBpm.value
-
-        if (movementBpm != null && audioBpm != null) {
-            if (abs(movementBpm - audioBpm) < 5.0) {
-                _systemStatus.value = "BPM Match Found! Saving snippet..."
-                vibrateOnMatch()
-                saveAudioSnippet()
-                _movementBpm.value = null
-                _audioBpm.value = null
-                _movementStatus.value = "Movement: -- BPM"
-                _audioStatus.value = "Song: -- BPM"
-            }
-        }
-    }
-
-    private fun vibrateOnMatch() {
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                vibrator?.vibrate(VibrationEffect.createOneShot(200, VibrationEffect.DEFAULT_AMPLITUDE))
-            } else {
-                @Suppress("DEPRECATION")
-                vibrator?.vibrate(200)
-            }
-        } catch (_: Exception) { /* Vibration not available */ }
-    }
-
-    private fun saveAudioSnippet() {
-        try {
-            val timestamp = System.currentTimeMillis()
-            val storageDir = getApplication<Application>().getExternalFilesDir(null)
-            val file = File(storageDir, "MadeMeDance_snippet_$timestamp.mmd")
-            audioBpmDetector.saveSnippet(file)
-            _systemStatus.value = "Snippet saved to ${file.name}"
-        } catch (e: IOException) {
-            _systemStatus.value = "Error saving snippet."
-        }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        stopSensors()
-        stopAudioProcessing()
+    fun stopService() {
+        BeatMatcherService.stop(getApplication())
     }
 }

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherActionReceiver.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherActionReceiver.kt
@@ -1,0 +1,18 @@
+package com.hereliesaz.mademedance.service
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class BeatMatcherActionReceiver : BroadcastReceiver() {
+
+    companion object {
+        const val ACTION_STOP = "com.hereliesaz.mademedance.action.NOTIFICATION_STOP"
+    }
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action == ACTION_STOP) {
+            BeatMatcherService.stop(context)
+        }
+    }
+}

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
@@ -46,6 +46,9 @@ class BeatMatcherService : Service() {
         private const val NOTIFICATION_ID_STATUS = 1001
         private const val NOTIFICATION_ID_MATCH_BASE = 2000
 
+        private const val BPM_MATCH_THRESHOLD = 5.0
+        private const val NOTIFICATION_UPDATE_INTERVAL_MS = 1000L
+
         fun start(context: Context) {
             val intent = Intent(context, BeatMatcherService::class.java).setAction(ACTION_START)
             ContextCompat.startForegroundService(context, intent)
@@ -60,6 +63,7 @@ class BeatMatcherService : Service() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var audioJob: Job? = null
     private var sensorJob: Job? = null
+    private var notificationJob: Job? = null
 
     private lateinit var audioBpmDetector: AudioBpmDetector
     private lateinit var movementTracker: MovementTracker
@@ -113,6 +117,8 @@ class BeatMatcherService : Service() {
 
         if (!hasMic) {
             BeatMatcherState.setSystemStatus("Microphone permission required.")
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
             return
         }
 
@@ -141,12 +147,19 @@ class BeatMatcherService : Service() {
                 delay(100)
             }
         }
+
+        notificationJob = scope.launch {
+            while (isActive) {
+                delay(NOTIFICATION_UPDATE_INTERVAL_MS)
+                updateForegroundNotification()
+            }
+        }
     }
 
     private fun checkForMatch() {
         val movement = BeatMatcherState.movementBpm.value
         val audio = BeatMatcherState.audioBpm.value
-        if (movement != null && audio != null && abs(movement - audio) < 5.0) {
+        if (movement != null && audio != null && abs(movement - audio) < BPM_MATCH_THRESHOLD) {
             BeatMatcherState.setSystemStatus("BPM match! Saving snippet...")
             vibrateOnMatch()
             val savedFile = saveAudioSnippet()
@@ -185,6 +198,7 @@ class BeatMatcherService : Service() {
     private fun stopWork() {
         audioJob?.cancel(); audioJob = null
         sensorJob?.cancel(); sensorJob = null
+        notificationJob?.cancel(); notificationJob = null
         try { audioBpmDetector.stop() } catch (_: Exception) {}
         try { movementTracker.stop() } catch (_: Exception) {}
         releaseWakeLock()
@@ -205,7 +219,7 @@ class BeatMatcherService : Service() {
         val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
         wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MadeMeDance::BeatMatcher").apply {
             setReferenceCounted(false)
-            acquire(60L * 60L * 1000L) // 1 hour safety cap; service will re-acquire if needed
+            acquire()
         }
     }
 

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
@@ -1,0 +1,332 @@
+package com.hereliesaz.mademedance.service
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.hardware.SensorManager
+import android.os.Build
+import android.os.IBinder
+import android.os.PowerManager
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.hereliesaz.mademedance.AudioBpmDetector
+import com.hereliesaz.mademedance.MainActivity
+import com.hereliesaz.mademedance.R
+import com.hereliesaz.mademedance.sensor.MovementTracker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.io.File
+import java.io.IOException
+import kotlin.math.abs
+
+class BeatMatcherService : Service() {
+
+    companion object {
+        const val ACTION_START = "com.hereliesaz.mademedance.action.START"
+        const val ACTION_STOP = "com.hereliesaz.mademedance.action.STOP"
+
+        private const val CHANNEL_STATUS = "beat_matcher_status"
+        private const val CHANNEL_MATCHES = "beat_matcher_matches"
+        private const val NOTIFICATION_ID_STATUS = 1001
+        private const val NOTIFICATION_ID_MATCH_BASE = 2000
+
+        fun start(context: Context) {
+            val intent = Intent(context, BeatMatcherService::class.java).setAction(ACTION_START)
+            ContextCompat.startForegroundService(context, intent)
+        }
+
+        fun stop(context: Context) {
+            val intent = Intent(context, BeatMatcherService::class.java).setAction(ACTION_STOP)
+            context.startService(intent)
+        }
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var audioJob: Job? = null
+    private var sensorJob: Job? = null
+
+    private lateinit var audioBpmDetector: AudioBpmDetector
+    private lateinit var movementTracker: MovementTracker
+    private var wakeLock: PowerManager.WakeLock? = null
+    private var matchCounter = 0
+
+    private val vibrator: Vibrator? by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as? VibratorManager)?.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannels()
+        val sensorManager = getSystemService(Context.SENSOR_SERVICE) as SensorManager
+        movementTracker = MovementTracker(sensorManager)
+        audioBpmDetector = AudioBpmDetector()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                stopWork()
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            else -> startWork()
+        }
+        return START_STICKY
+    }
+
+    private fun startWork() {
+        if (BeatMatcherState.isRunning.value) return
+
+        startForegroundWithNotification()
+        acquireWakeLock()
+
+        BeatMatcherState.setRunning(true)
+        BeatMatcherState.setSystemStatus("Listening...")
+
+        val hasMic = ContextCompat.checkSelfPermission(
+            this, Manifest.permission.RECORD_AUDIO
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (!hasMic) {
+            BeatMatcherState.setSystemStatus("Microphone permission required.")
+            return
+        }
+
+        if (movementTracker.isAvailable) {
+            movementTracker.start()
+            sensorJob = scope.launch {
+                movementTracker.bpm.collect { bpm ->
+                    if (bpm != null) {
+                        BeatMatcherState.setMovementBpm(bpm)
+                        checkForMatch()
+                    }
+                }
+            }
+        } else {
+            BeatMatcherState.setSystemStatus("No gyroscope sensor on this device.")
+        }
+
+        audioJob = scope.launch {
+            audioBpmDetector.start()
+            while (isActive) {
+                val bpm = audioBpmDetector.processAudio()
+                if (bpm != null) {
+                    BeatMatcherState.setAudioBpm(bpm)
+                    checkForMatch()
+                }
+                delay(100)
+            }
+        }
+    }
+
+    private fun checkForMatch() {
+        val movement = BeatMatcherState.movementBpm.value
+        val audio = BeatMatcherState.audioBpm.value
+        if (movement != null && audio != null && abs(movement - audio) < 5.0) {
+            BeatMatcherState.setSystemStatus("BPM match! Saving snippet...")
+            vibrateOnMatch()
+            val savedFile = saveAudioSnippet()
+            BeatMatcherState.setMovementBpm(null)
+            BeatMatcherState.setAudioBpm(null)
+            if (savedFile != null) {
+                postMatchNotification()
+                BeatMatcherState.notifyClipsChanged()
+            }
+            updateForegroundNotification()
+        }
+    }
+
+    private fun saveAudioSnippet(): File? = try {
+        val timestamp = System.currentTimeMillis()
+        val file = File(getExternalFilesDir(null), "MadeMeDance_snippet_$timestamp.mmd")
+        audioBpmDetector.saveSnippet(file)
+        BeatMatcherState.setSystemStatus("Snippet saved: ${file.name}")
+        file
+    } catch (e: IOException) {
+        BeatMatcherState.setSystemStatus("Error saving snippet.")
+        null
+    }
+
+    private fun vibrateOnMatch() {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                vibrator?.vibrate(VibrationEffect.createOneShot(200, VibrationEffect.DEFAULT_AMPLITUDE))
+            } else {
+                @Suppress("DEPRECATION")
+                vibrator?.vibrate(200)
+            }
+        } catch (_: Exception) { /* no vibrator */ }
+    }
+
+    private fun stopWork() {
+        audioJob?.cancel(); audioJob = null
+        sensorJob?.cancel(); sensorJob = null
+        try { audioBpmDetector.stop() } catch (_: Exception) {}
+        try { movementTracker.stop() } catch (_: Exception) {}
+        releaseWakeLock()
+        BeatMatcherState.setRunning(false)
+        BeatMatcherState.setMovementBpm(null)
+        BeatMatcherState.setAudioBpm(null)
+        BeatMatcherState.setSystemStatus("Service stopped.")
+    }
+
+    override fun onDestroy() {
+        stopWork()
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    private fun acquireWakeLock() {
+        if (wakeLock?.isHeld == true) return
+        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MadeMeDance::BeatMatcher").apply {
+            setReferenceCounted(false)
+            acquire(60L * 60L * 1000L) // 1 hour safety cap; service will re-acquire if needed
+        }
+    }
+
+    private fun releaseWakeLock() {
+        try { wakeLock?.takeIf { it.isHeld }?.release() } catch (_: Exception) {}
+        wakeLock = null
+    }
+
+    private fun createNotificationChannels() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val nm = getSystemService(NotificationManager::class.java) ?: return
+        nm.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_STATUS,
+                "Listening status",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Ongoing notification while MadeMeDance is listening."
+                setShowBadge(false)
+            }
+        )
+        nm.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_MATCHES,
+                "BPM matches",
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = "Posted when your movement matches the music's beat."
+            }
+        )
+    }
+
+    private fun startForegroundWithNotification() {
+        val notification = buildStatusNotification()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID_STATUS,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            )
+        } else {
+            startForeground(NOTIFICATION_ID_STATUS, notification)
+        }
+    }
+
+    private fun updateForegroundNotification() {
+        val nm = NotificationManagerCompat.from(this)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+            != PackageManager.PERMISSION_GRANTED
+        ) return
+        nm.notify(NOTIFICATION_ID_STATUS, buildStatusNotification())
+    }
+
+    private fun buildStatusNotification(): android.app.Notification {
+        val contentIntent = PendingIntent.getActivity(
+            this, 0,
+            Intent(this, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        val stopPi = PendingIntent.getBroadcast(
+            this, 1,
+            Intent(this, BeatMatcherActionReceiver::class.java)
+                .setAction(BeatMatcherActionReceiver.ACTION_STOP),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val movement = BeatMatcherState.movementBpm.value
+        val audio = BeatMatcherState.audioBpm.value
+        val title = "MadeMeDance is listening"
+        val body = buildString {
+            append(movement?.let { "You: ${"%.0f".format(it)} BPM" } ?: "You: -- BPM")
+            append("   ")
+            append(audio?.let { "Song: ${"%.0f".format(it)} BPM" } ?: "Song: -- BPM")
+        }
+
+        return NotificationCompat.Builder(this, CHANNEL_STATUS)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setContentIntent(contentIntent)
+            .setOngoing(true)
+            .setSilent(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .addAction(0, "Stop", stopPi)
+            .build()
+    }
+
+    private fun postMatchNotification() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+            != PackageManager.PERMISSION_GRANTED
+        ) return
+
+        val openClips = PendingIntent.getActivity(
+            this, 100,
+            Intent(this, MainActivity::class.java)
+                .putExtra(MainActivity.EXTRA_OPEN_CLIPS, true)
+                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        val identify = PendingIntent.getActivity(
+            this, 101,
+            Intent(android.content.Intent.ACTION_WEB_SEARCH)
+                .putExtra(android.app.SearchManager.QUERY, "what is this song")
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val notification = NotificationCompat.Builder(this, CHANNEL_MATCHES)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("You're dancing to something!")
+            .setContentText("15 s snippet saved — tap Identify to find the song.")
+            .setContentIntent(openClips)
+            .setAutoCancel(true)
+            .addAction(0, "Identify", identify)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+
+        NotificationManagerCompat.from(this)
+            .notify(NOTIFICATION_ID_MATCH_BASE + (matchCounter++), notification)
+    }
+}

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherState.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherState.kt
@@ -1,0 +1,41 @@
+package com.hereliesaz.mademedance.service
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+object BeatMatcherState {
+
+    private val _isRunning = MutableStateFlow(false)
+    val isRunning: StateFlow<Boolean> = _isRunning.asStateFlow()
+
+    private val _movementBpm = MutableStateFlow<Float?>(null)
+    val movementBpm: StateFlow<Float?> = _movementBpm.asStateFlow()
+
+    private val _audioBpm = MutableStateFlow<Float?>(null)
+    val audioBpm: StateFlow<Float?> = _audioBpm.asStateFlow()
+
+    private val _movementStatus = MutableStateFlow("Movement: -- BPM")
+    val movementStatus: StateFlow<String> = _movementStatus.asStateFlow()
+
+    private val _audioStatus = MutableStateFlow("Song: -- BPM")
+    val audioStatus: StateFlow<String> = _audioStatus.asStateFlow()
+
+    private val _systemStatus = MutableStateFlow("Service stopped.")
+    val systemStatus: StateFlow<String> = _systemStatus.asStateFlow()
+
+    private val _clipsChanged = MutableStateFlow(0)
+    val clipsChanged: StateFlow<Int> = _clipsChanged.asStateFlow()
+
+    internal fun setRunning(running: Boolean) { _isRunning.value = running }
+    internal fun setMovementBpm(bpm: Float?) {
+        _movementBpm.value = bpm
+        _movementStatus.value = bpm?.let { "Movement: ${"%.1f".format(it)} BPM" } ?: "Movement: -- BPM"
+    }
+    internal fun setAudioBpm(bpm: Float?) {
+        _audioBpm.value = bpm
+        _audioStatus.value = bpm?.let { "Song: ${"%.1f".format(it)} BPM" } ?: "Song: -- BPM"
+    }
+    internal fun setSystemStatus(message: String) { _systemStatus.value = message }
+    internal fun notifyClipsChanged() { _clipsChanged.value = _clipsChanged.value + 1 }
+}

--- a/app/src/main/java/com/hereliesaz/mademedance/ui/ClipListScreen.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/ui/ClipListScreen.kt
@@ -41,6 +41,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.hereliesaz.mademedance.data.ClipItem
 import com.hereliesaz.mademedance.data.ClipRepository
+import com.hereliesaz.mademedance.service.BeatMatcherState
+import kotlinx.coroutines.flow.collectLatest
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,11 +54,13 @@ fun ClipListScreen(
     val clips = remember { mutableStateListOf<ClipItem>() }
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    // Refresh clip list whenever this screen becomes visible
+    // Refresh clip list whenever this screen becomes visible or the service signals a new clip
     LaunchedEffect(lifecycleOwner) {
         lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-            clips.clear()
-            clips.addAll(clipRepository.getClips())
+            BeatMatcherState.clipsChanged.collectLatest {
+                clips.clear()
+                clips.addAll(clipRepository.getClips())
+            }
         }
     }
 

--- a/app/src/main/java/com/hereliesaz/mademedance/ui/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/ui/MainScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -45,8 +46,11 @@ fun MainScreen(
     audioStatus: String,
     systemStatus: String,
     hasAudioPermission: Boolean,
+    isServiceRunning: Boolean,
     movementBpm: Float?,
     audioBpm: Float?,
+    onStartClick: () -> Unit,
+    onStopClick: () -> Unit,
     onPermissionClick: () -> Unit,
     onClipListClick: () -> Unit
 ) {
@@ -70,33 +74,22 @@ fun MainScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            // Pulse ring visualization
             PulseRing(
                 movementBpm = movementBpm,
-                audioBpm = audioBpm
+                audioBpm = audioBpm,
+                active = isServiceRunning
             )
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            // BPM displays
-            Text(
-                text = movementStatus,
-                style = MaterialTheme.typography.titleMedium
-            )
+            Text(text = movementStatus, style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = audioStatus,
-                style = MaterialTheme.typography.titleMedium
-            )
+            Text(text = audioStatus, style = MaterialTheme.typography.titleMedium)
 
             Spacer(modifier = Modifier.height(16.dp))
-
-            // Match proximity bar
             MatchProximityBar(movementBpm = movementBpm, audioBpm = audioBpm)
-
             Spacer(modifier = Modifier.height(24.dp))
 
-            // System status
             Text(
                 text = systemStatus,
                 style = MaterialTheme.typography.bodyLarge,
@@ -105,17 +98,43 @@ fun MainScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            // Permission button or listening indicator
-            if (!hasAudioPermission) {
-                Button(onClick = onPermissionClick) {
-                    Text("Enable Microphone")
+            when {
+                !hasAudioPermission -> {
+                    Button(onClick = onPermissionClick) {
+                        Text("Enable Microphone & Start")
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "MadeMeDance listens in the background. You can close the app.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
                 }
-            } else {
-                Text(
-                    text = "Listening for music...",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary
-                )
+                isServiceRunning -> {
+                    OutlinedButton(onClick = onStopClick) {
+                        Text("Stop listening")
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Running in the background. Close the app — it'll keep listening.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        textAlign = TextAlign.Center
+                    )
+                }
+                else -> {
+                    Button(onClick = onStartClick) {
+                        Text("Start listening")
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Tap to start. The app runs as a background service — you don't need to keep it open.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                }
             }
         }
     }
@@ -124,19 +143,19 @@ fun MainScreen(
 @Composable
 private fun PulseRing(
     movementBpm: Float?,
-    audioBpm: Float?
+    audioBpm: Float?,
+    active: Boolean
 ) {
     val proximity = if (movementBpm != null && audioBpm != null) {
         val diff = abs(movementBpm - audioBpm)
-        (1f - (diff / 30f).coerceIn(0f, 1f)) // Closer = higher value
-    } else {
-        0f
-    }
+        (1f - (diff / 30f).coerceIn(0f, 1f))
+    } else 0f
 
     val ringColor by animateColorAsState(
         targetValue = when {
-            proximity > 0.83f -> Color(0xFF4CAF50) // Green — near match
-            proximity > 0.5f -> Color(0xFFFFC107)  // Amber — getting close
+            !active -> MaterialTheme.colorScheme.outlineVariant
+            proximity > 0.83f -> Color(0xFF4CAF50)
+            proximity > 0.5f -> Color(0xFFFFC107)
             movementBpm != null -> MaterialTheme.colorScheme.primary
             else -> MaterialTheme.colorScheme.outlineVariant
         },
@@ -144,13 +163,10 @@ private fun PulseRing(
         label = "ringColor"
     )
 
-    // Pulse animation based on movement BPM
     val infiniteTransition = rememberInfiniteTransition(label = "pulse")
     val pulseDurationMs = if (movementBpm != null && movementBpm > 0f) {
         (60_000f / movementBpm).toInt().coerceIn(300, 2000)
-    } else {
-        1000
-    }
+    } else 1000
     val pulseScale by infiniteTransition.animateFloat(
         initialValue = 0.85f,
         targetValue = 1f,
@@ -161,7 +177,7 @@ private fun PulseRing(
         label = "pulseScale"
     )
 
-    val scale = if (movementBpm != null) pulseScale else 0.92f
+    val scale = if (active && movementBpm != null) pulseScale else 0.92f
 
     Box(
         contentAlignment = Alignment.Center,
@@ -174,7 +190,6 @@ private fun PulseRing(
                 radius = radius,
                 style = Stroke(width = 6.dp.toPx())
             )
-            // Inner glow ring when close to match
             if (proximity > 0.5f) {
                 drawCircle(
                     color = ringColor.copy(alpha = proximity * 0.3f),
@@ -183,7 +198,6 @@ private fun PulseRing(
                 )
             }
         }
-        // BPM text inside the ring
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
                 text = movementBpm?.let { "%.0f".format(it) } ?: "--",
@@ -207,10 +221,8 @@ private fun MatchProximityBar(
     val progress by animateFloatAsState(
         targetValue = if (movementBpm != null && audioBpm != null) {
             val diff = abs(movementBpm - audioBpm)
-            (1f - (diff / 10f)).coerceIn(0f, 1f) // 0 BPM diff = 100%, 10+ BPM diff = 0%
-        } else {
-            0f
-        },
+            (1f - (diff / 10f)).coerceIn(0f, 1f)
+        } else 0f,
         animationSpec = tween(300),
         label = "matchProgress"
     )


### PR DESCRIPTION
## Summary

The whole point of MadeMeDance is to catch songs you're dancing to without breaking the spell of dancing — but the old flow required the app to be in the foreground for any detection to happen. That's the bug. This PR moves the detection engine into a foreground service so it keeps listening with the app closed and the screen off.

## What changed

- **New `BeatMatcherService`** (`foregroundServiceType="microphone"`) owns the `AudioBpmDetector`, the `MovementTracker`, the match check, snippet save, and vibration. Holds a partial wake lock while running.
- **`BeatMatcherState`** singleton (StateFlows) bridges service → UI without bind/unbind ceremony.
- **Persistent status notification** (low priority, silent) shows the current movement / song BPM and has a **Stop** action. Routed through `BeatMatcherActionReceiver`.
- **Match notification** (default priority) fires when a clip is saved, with an **Identify** action that launches the existing web-search intent (mirrors the dialog flow in `ClipListScreen`).
- **`MainViewModel`** slimmed to a state reader plus `startService()` / `stopService()`.
- **`MainScreen`** now has explicit **Start listening** / **Stop listening** controls and copy that tells the user the app keeps running in the background.
- **`ClipListScreen`** refreshes on `BeatMatcherState.clipsChanged` so newly-saved clips appear without re-opening the screen.
- **Manifest**: added `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_MICROPHONE`, `POST_NOTIFICATIONS`, `WAKE_LOCK`, `VIBRATE`; declared the service and receiver; marked gyroscope as a non-required feature.
- **Activity** now requests `POST_NOTIFICATIONS` after `RECORD_AUDIO` on Android 13+, then starts the service.

## Test plan

- [ ] Build with the Android SDK locally (this remote container has no SDK, so I couldn't run `./gradlew assembleDebug`).
- [ ] Grant mic + notifications, hit **Start listening**, swipe the app away — confirm the status notification stays and BPM keeps updating in it.
- [ ] Trigger a match — confirm vibration, "match saved" notification, and the **Identify** action opens web search.
- [ ] Hit **Stop** from the notification — service stops, ongoing notification disappears.
- [ ] Re-open the app — Start/Stop button reflects the live service state, recorded clips list shows the new clip.
- [ ] Device with no gyroscope: status surfaces the "No gyroscope sensor" message, service still records audio (will not save snippets without a movement match — that's existing behavior).
- [ ] Run `./gradlew :app:testDebugUnitTest` — the existing tests cover `ClipRepository` / `RhythmDetector` / `AudioBpmDetector`, none of which changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DSwbN23GDY58SDdpK7sjEg)_

## Summary by Sourcery

Run BPM matching in a persistent foreground service and expose its state to the UI via a shared singleton, enabling background listening with notifications.

New Features:
- Introduce BeatMatcherService foreground service that handles audio BPM detection, movement tracking, match detection, snippet saving, and match notifications while the app is in the background.
- Add BeatMatcherState singleton to expose service state (BPM values, statuses, running flag, clip change events) to the UI without explicit binding.
- Display an ongoing status notification with current movement/song BPM and a Stop action while the service is listening.
- Show a match notification when a snippet is saved, with an Identify action that opens song search and a shortcut to the clips list.

Bug Fixes:
- Ensure BPM detection continues running when the app is closed or the screen is off by moving work into a foreground service with a wake lock.

Enhancements:
- Simplify MainViewModel to delegate BPM state to BeatMatcherState and manage service start/stop without binding.
- Update the main screen controls and copy to clearly distinguish Start/Stop listening and explain that listening continues in the background, with visual feedback when inactive.
- Refresh the clip list reactively when new snippets are saved by observing a clipsChanged signal from the service state.
- Improve permission handling to coordinate microphone and notification permissions before starting the service, including Android 13+ POST_NOTIFICATIONS.

Build:
- Update AndroidManifest to declare the new foreground service and broadcast receiver, add wake lock and vibration permissions, and mark the gyroscope as an optional feature.