### PR TITLE
Accelerometer movement detection + sensitivity tuner (manual, rating, battery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,17 @@ An Android app that identifies songs by matching your body's rhythm to the music
 1. The app detects your **movement BPM** via the accelerometer (so it works with the phone in your pocket)
 2. Simultaneously detects the **music BPM** via the microphone
 3. When both BPMs match (within 5 BPM tolerance), a 15-second audio snippet is saved
-4. You can review saved clips and identify songs via Google Search
+4. You can review saved clips and identify the song
+
+### Identifying the song
+
+Tapping **Identify** runs a free, no-API chain:
+
+1. If media is **playing on the device**, read the title/artist straight from the active media session (needs one-time *notification access*, offered via "Enable now-playing detection").
+2. Otherwise launch the best installed recognizer — **Google** (Sound Search) first, then Shazam / SoundHound / Musixmatch — which listens live.
+3. If none is installed, open a web search and prompt you to install one.
+
+(Recognizer apps listen to live audio — they can't ingest the saved clip, so they only help while the song is still playing. The saved clip remains the manual backstop.)
 
 It runs as a background **foreground service**, so you can pocket the phone and keep dancing — no need to keep the app open. The cheap accelerometer runs continuously, but the **microphone only switches on once dancing is detected** and switches off again a few seconds after you stop — saving battery and keeping the mic off while you're still.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ An Android app that identifies songs by matching your body's rhythm to the music
 3. When both BPMs match (within 5 BPM tolerance), a 15-second audio snippet is saved
 4. You can review saved clips and identify songs via Google Search
 
+It runs as a background **foreground service**, so you can pocket the phone and keep dancing — no need to keep the app open.
+
+### Tuning sensitivity
+
+- A **sensitivity knob** on the main screen sets how much movement counts as dancing (lower for vigorous dancing, higher for subtle motion).
+- Rating a saved clip **"False alarm"** nudges sensitivity down automatically (one-way — the app never raises it on its own; you do that with the knob).
+- The service watches its own **battery drain** and, when consumption is high, enters a power-saving mode that reduces sensitivity and stretches the audio-processing interval.
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Android app that identifies songs by matching your body's rhythm to the music
 
 ## How It Works
 
-1. The app detects your **movement BPM** via the gyroscope sensor
+1. The app detects your **movement BPM** via the accelerometer (so it works with the phone in your pocket)
 2. Simultaneously detects the **music BPM** via the microphone
 3. When both BPMs match (within 5 BPM tolerance), a 15-second audio snippet is saved
 4. You can review saved clips and identify songs via Google Search
@@ -16,11 +16,11 @@ mademedance/
 ├── MainActivity.kt              # Thin shell: permissions, lifecycle, Compose UI
 ├── MainViewModel.kt             # Business logic, state management, coordination
 ├── AudioBpmDetector.kt          # FFT-based beat detection on microphone audio
-├── RhythmDetector.kt            # FFT-based movement BPM from gyroscope
+├── RhythmDetector.kt            # FFT-based movement BPM from accelerometer
 ├── data/
 │   └── ClipRepository.kt       # File-based clip management (list, delete)
 ├── sensor/
-│   └── MovementTracker.kt      # Gyroscope sensor wrapper, exposes BPM StateFlow
+│   └── MovementTracker.kt      # Accelerometer sensor wrapper, exposes BPM StateFlow
 └── ui/
     ├── MainScreen.kt            # Pulse ring animation, match proximity bar
     ├── ClipListScreen.kt        # Clip list with playback, deletion, identification

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An Android app that identifies songs by matching your body's rhythm to the music
 3. When both BPMs match (within 5 BPM tolerance), a 15-second audio snippet is saved
 4. You can review saved clips and identify songs via Google Search
 
-It runs as a background **foreground service**, so you can pocket the phone and keep dancing — no need to keep the app open.
+It runs as a background **foreground service**, so you can pocket the phone and keep dancing — no need to keep the app open. The cheap accelerometer runs continuously, but the **microphone only switches on once dancing is detected** and switches off again a few seconds after you stop — saving battery and keeping the mic off while you're still.
 
 ### Tuning sensitivity
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ An Android app that identifies songs by matching your body's rhythm to the music
 
 ### Identifying the song
 
-Tapping **Identify** runs a free, no-API chain:
+The app tries to know the song as early as possible, and gives you several ways to find it later — all free, no paid API:
 
-1. If media is **playing on the device**, read the title/artist straight from the active media session (needs one-time *notification access*, offered via "Enable now-playing detection").
-2. Otherwise launch the best installed recognizer — **Google** (Sound Search) first, then Shazam / SoundHound / Musixmatch — which listens live.
-3. If none is installed, open a web search and prompt you to install one.
+- **At match time:** if the music is playing **through the phone**, the song's title/artist is read from the active media session and stored with the clip automatically (needs one-time *notification access*, offered via "Enable now-playing detection").
+- **From a saved clip, later:**
+  - **Identify this clip** — uploads the clip to ACRCloud (your own free-tier key, entered in Settings, stored encrypted on-device) and recognizes it even after the song has stopped.
+  - **Play to a song finder** — loops the clip out the speaker and opens an installed recognizer (Google Sound Search / Shazam / SoundHound) to listen.
+  - **What's playing now** — the live chain: read the device's now-playing, else launch a recognizer, else web-search.
 
-(Recognizer apps listen to live audio — they can't ingest the saved clip, so they only help while the song is still playing. The saved clip remains the manual backstop.)
+Once a clip's song is known, it shows the title/artist in the list with a one-tap web search.
 
 It runs as a background **foreground service**, so you can pocket the phone and keep dancing — no need to keep the app open. The cheap accelerometer runs continuously, but the **microphone only switches on once dancing is detected** and switches off again a few seconds after you stop — saving battery and keeping the mic off while you're still.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
     implementation(libs.androidx.compose.material.icons)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.security.crypto)
 
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.tooling.preview)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,18 @@
         android:name="android.hardware.sensor.accelerometer"
         android:required="false" />
 
+    <!-- Package visibility (API 30+) so we can detect/launch song recognizers. -->
+    <queries>
+        <package android:name="com.google.android.googlequicksearchbox" />
+        <package android:name="com.shazam.android" />
+        <package android:name="com.melodis.midomiMusicIdentifier.freemium" />
+        <package android:name="com.melodis.midomiMusicIdentifier" />
+        <package android:name="com.musixmatch.android.lyrify" />
+        <intent>
+            <action android:name="android.intent.action.WEB_SEARCH" />
+        </intent>
+    </queries>
+
     <application
         android:name=".MadeMeDanceApp"
         android:allowBackup="true"
@@ -38,6 +50,15 @@
             android:name=".service.BeatMatcherService"
             android:exported="false"
             android:foregroundServiceType="microphone" />
+
+        <service
+            android:name=".identify.NowPlayingListenerService"
+            android:exported="false"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
 
         <receiver
             android:name=".service.BeatMatcherActionReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <uses-feature
-        android:name="android.hardware.sensor.gyroscope"
+        android:name="android.hardware.sensor.accelerometer"
         android:required="false" />
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:required="false" />
 
     <application
+        android:name=".MadeMeDanceApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/hereliesaz/mademedance/AudioBpmDetector.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/AudioBpmDetector.kt
@@ -25,6 +25,14 @@ class AudioBpmDetector {
 
     @SuppressLint("MissingPermission")
     fun start() {
+        // Reset per-session state: the mic cycles on and off with movement, so
+        // stale beat timestamps or buffered audio from a previous session must
+        // not bleed into the next one.
+        energyHistory.clear()
+        beatTimestamps.clear()
+        ringWritePos = 0
+        ringBufferFilled = false
+
         bufferSize = AudioRecord.getMinBufferSize(sampleRate, channelConfig, audioFormat)
             .coerceAtLeast(fftSize * 2) // Ensure buffer is at least fftSize samples (16-bit = 2 bytes each)
         audioRecord = AudioRecord(

--- a/app/src/main/java/com/hereliesaz/mademedance/MadeMeDanceApp.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MadeMeDanceApp.kt
@@ -1,0 +1,11 @@
+package com.hereliesaz.mademedance
+
+import android.app.Application
+import com.hereliesaz.mademedance.settings.SettingsStore
+
+class MadeMeDanceApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        SettingsStore.init(this)
+    }
+}

--- a/app/src/main/java/com/hereliesaz/mademedance/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainActivity.kt
@@ -65,6 +65,9 @@ class MainActivity : ComponentActivity() {
                 val isRunning by vm.isServiceRunning.collectAsState()
                 val movementBpm by vm.movementBpm.collectAsState()
                 val audioBpm by vm.audioBpm.collectAsState()
+                val sensitivity by vm.sensitivity.collectAsState()
+                val batteryDrain by vm.batteryDrainPerHour.collectAsState()
+                val powerSaving by vm.powerSaving.collectAsState()
                 val navController = rememberNavController()
 
                 var navigatedToClips by remember { mutableStateOf(false) }
@@ -85,6 +88,10 @@ class MainActivity : ComponentActivity() {
                             isServiceRunning = isRunning,
                             movementBpm = movementBpm,
                             audioBpm = audioBpm,
+                            sensitivity = sensitivity,
+                            batteryDrainPerHour = batteryDrain,
+                            powerSaving = powerSaving,
+                            onSensitivityChange = { vm.setSensitivity(it) },
                             onStartClick = { requestPermissionsAndStart() },
                             onStopClick = { vm.stopService() },
                             onPermissionClick = { requestPermissionsAndStart() },
@@ -94,6 +101,8 @@ class MainActivity : ComponentActivity() {
                     composable("clip_list") {
                         ClipListScreen(
                             clipRepository = vm.clipRepository,
+                            onAccept = { vm.acceptClip() },
+                            onReject = { vm.rejectClip(it) },
                             onBackClick = { navController.popBackStack() }
                         )
                     }

--- a/app/src/main/java/com/hereliesaz/mademedance/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainActivity.kt
@@ -23,6 +23,7 @@ import com.hereliesaz.mademedance.identify.SongIdentifier
 import com.hereliesaz.mademedance.ui.ClipListScreen
 import com.hereliesaz.mademedance.ui.MainScreen
 import com.hereliesaz.mademedance.ui.NowPlayingDialog
+import com.hereliesaz.mademedance.ui.SettingsScreen
 import com.hereliesaz.mademedance.ui.runIdentify
 import com.hereliesaz.mademedance.ui.theme.MadeMeDanceTheme
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -82,6 +83,11 @@ class MainActivity : ComponentActivity() {
                 val batteryDrain by vm.batteryDrainPerHour.collectAsState()
                 val powerSaving by vm.powerSaving.collectAsState()
                 val hasNowPlayingAccess by vm.hasNowPlayingAccess.collectAsState()
+                val acrConfigured by vm.acrConfigured.collectAsState()
+                val recognition by vm.recognition.collectAsState()
+                val acrHost by vm.acrHost.collectAsState()
+                val acrKey by vm.acrKey.collectAsState()
+                val acrSecret by vm.acrSecret.collectAsState()
                 val navController = rememberNavController()
 
                 var navigatedToClips by remember { mutableStateOf(false) }
@@ -129,15 +135,29 @@ class MainActivity : ComponentActivity() {
                             onStartClick = { requestPermissionsAndStart() },
                             onStopClick = { vm.stopService() },
                             onPermissionClick = { requestPermissionsAndStart() },
-                            onClipListClick = { navController.navigate("clip_list") }
+                            onClipListClick = { navController.navigate("clip_list") },
+                            onSettingsClick = { navController.navigate("settings") }
                         )
                     }
                     composable("clip_list") {
                         ClipListScreen(
                             clipRepository = vm.clipRepository,
+                            acrConfigured = acrConfigured,
+                            recognition = recognition,
                             onAccept = { vm.acceptClip() },
                             onReject = { vm.rejectClip(it) },
+                            onRecognize = { vm.recognizeClip(it) },
+                            onClearRecognition = { vm.clearRecognition() },
                             onBackClick = { navController.popBackStack() }
+                        )
+                    }
+                    composable("settings") {
+                        SettingsScreen(
+                            acrHost = acrHost,
+                            acrKey = acrKey,
+                            acrSecret = acrSecret,
+                            onSave = { h, k, s -> vm.setAcrCredentials(h, k, s) },
+                            onBack = { navController.popBackStack() }
                         )
                     }
                 }

--- a/app/src/main/java/com/hereliesaz/mademedance/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainActivity.kt
@@ -18,18 +18,28 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.hereliesaz.mademedance.identify.IdentifyResult
+import com.hereliesaz.mademedance.identify.SongIdentifier
 import com.hereliesaz.mademedance.ui.ClipListScreen
 import com.hereliesaz.mademedance.ui.MainScreen
+import com.hereliesaz.mademedance.ui.NowPlayingDialog
+import com.hereliesaz.mademedance.ui.runIdentify
 import com.hereliesaz.mademedance.ui.theme.MadeMeDanceTheme
+import kotlinx.coroutines.flow.MutableStateFlow
 
 class MainActivity : ComponentActivity() {
 
     companion object {
         const val EXTRA_OPEN_CLIPS = "open_clips"
+        const val EXTRA_IDENTIFY = "identify"
     }
 
     private lateinit var viewModel: MainViewModel
     private var pendingStartAfterPermissions = false
+
+    // Bumped each time an "Identify" intent arrives (cold start or onNewIntent),
+    // so the Compose tree can run the identification chain exactly once per tap.
+    private val identifyTrigger = MutableStateFlow(0)
 
     private val requestAudioPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
@@ -52,6 +62,9 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         val openClipsOnLaunch = intent?.getBooleanExtra(EXTRA_OPEN_CLIPS, false) == true
+        if (intent?.getBooleanExtra(EXTRA_IDENTIFY, false) == true) {
+            identifyTrigger.value++
+        }
 
         setContent {
             MadeMeDanceTheme {
@@ -68,6 +81,7 @@ class MainActivity : ComponentActivity() {
                 val sensitivity by vm.sensitivity.collectAsState()
                 val batteryDrain by vm.batteryDrainPerHour.collectAsState()
                 val powerSaving by vm.powerSaving.collectAsState()
+                val hasNowPlayingAccess by vm.hasNowPlayingAccess.collectAsState()
                 val navController = rememberNavController()
 
                 var navigatedToClips by remember { mutableStateOf(false) }
@@ -76,6 +90,24 @@ class MainActivity : ComponentActivity() {
                         navController.navigate("clip_list")
                         navigatedToClips = true
                     }
+                }
+
+                var nowPlaying by remember { mutableStateOf<IdentifyResult.NowPlaying?>(null) }
+                val identify by identifyTrigger.collectAsState()
+                LaunchedEffect(identify) {
+                    if (identify > 0) {
+                        runIdentify(this@MainActivity) { nowPlaying = it }
+                    }
+                }
+                nowPlaying?.let { np ->
+                    NowPlayingDialog(
+                        nowPlaying = np,
+                        onSearch = {
+                            SongIdentifier.searchForKnownSong(this@MainActivity, np.artist, np.title)
+                            nowPlaying = null
+                        },
+                        onDismiss = { nowPlaying = null }
+                    )
                 }
 
                 NavHost(navController = navController, startDestination = "main") {
@@ -91,7 +123,9 @@ class MainActivity : ComponentActivity() {
                             sensitivity = sensitivity,
                             batteryDrainPerHour = batteryDrain,
                             powerSaving = powerSaving,
+                            hasNowPlayingAccess = hasNowPlayingAccess,
                             onSensitivityChange = { vm.setSensitivity(it) },
+                            onEnableNowPlaying = { SongIdentifier.openNotificationAccessSettings(this@MainActivity) },
                             onStartClick = { requestPermissionsAndStart() },
                             onStopClick = { vm.stopService() },
                             onPermissionClick = { requestPermissionsAndStart() },
@@ -114,6 +148,9 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        if (intent.getBooleanExtra(EXTRA_IDENTIFY, false)) {
+            identifyTrigger.value++
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
@@ -5,9 +5,11 @@ import android.app.Application
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
+import com.hereliesaz.mademedance.data.ClipItem
 import com.hereliesaz.mademedance.data.ClipRepository
 import com.hereliesaz.mademedance.service.BeatMatcherService
 import com.hereliesaz.mademedance.service.BeatMatcherState
+import com.hereliesaz.mademedance.settings.SettingsStore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,6 +23,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val systemStatus: StateFlow<String> = BeatMatcherState.systemStatus
     val isServiceRunning: StateFlow<Boolean> = BeatMatcherState.isRunning
 
+    val sensitivity: StateFlow<Float> = SettingsStore.sensitivity
+    val batteryDrainPerHour: StateFlow<Float?> = BeatMatcherState.batteryDrainPerHour
+    val powerSaving: StateFlow<Boolean> = BeatMatcherState.powerSaving
+
     private val _hasAudioPermission = MutableStateFlow(false)
     val hasAudioPermission: StateFlow<Boolean> = _hasAudioPermission.asStateFlow()
 
@@ -30,6 +36,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val clipRepository = ClipRepository(application.getExternalFilesDir(null))
 
     init {
+        SettingsStore.init(application)
         refreshPermissionState()
     }
 
@@ -52,5 +59,20 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun stopService() {
         BeatMatcherService.stop(getApplication())
+    }
+
+    fun setSensitivity(value: Float) {
+        SettingsStore.setSensitivity(value)
+    }
+
+    /** Good catch — keep the clip, confirm the current sensitivity. */
+    fun acceptClip() {
+        SettingsStore.recordAccept()
+    }
+
+    /** False trigger — delete the clip and back the detector off. */
+    fun rejectClip(clip: ClipItem) {
+        SettingsStore.recordReject()
+        clipRepository.deleteClip(clip.name)
     }
 }

--- a/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
@@ -7,6 +7,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import com.hereliesaz.mademedance.data.ClipItem
 import com.hereliesaz.mademedance.data.ClipRepository
+import com.hereliesaz.mademedance.identify.SongIdentifier
 import com.hereliesaz.mademedance.service.BeatMatcherService
 import com.hereliesaz.mademedance.service.BeatMatcherState
 import com.hereliesaz.mademedance.settings.SettingsStore
@@ -33,6 +34,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _hasNotificationPermission = MutableStateFlow(false)
     val hasNotificationPermission: StateFlow<Boolean> = _hasNotificationPermission.asStateFlow()
 
+    private val _hasNowPlayingAccess = MutableStateFlow(false)
+    val hasNowPlayingAccess: StateFlow<Boolean> = _hasNowPlayingAccess.asStateFlow()
+
     val clipRepository = ClipRepository(application.getExternalFilesDir(null))
 
     init {
@@ -51,6 +55,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     ctx, Manifest.permission.POST_NOTIFICATIONS
                 ) == PackageManager.PERMISSION_GRANTED
             } else true
+        _hasNowPlayingAccess.value = SongIdentifier.hasNotificationAccess(ctx)
     }
 
     fun startService() {

--- a/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
@@ -5,15 +5,29 @@ import android.app.Application
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
 import com.hereliesaz.mademedance.data.ClipItem
 import com.hereliesaz.mademedance.data.ClipRepository
+import com.hereliesaz.mademedance.identify.AcrCloudClient
+import com.hereliesaz.mademedance.identify.AcrOutcome
 import com.hereliesaz.mademedance.identify.SongIdentifier
 import com.hereliesaz.mademedance.service.BeatMatcherService
 import com.hereliesaz.mademedance.service.BeatMatcherState
 import com.hereliesaz.mademedance.settings.SettingsStore
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+sealed interface ClipRecognition {
+    data object Idle : ClipRecognition
+    data object Loading : ClipRecognition
+    data class Done(val artist: String?, val title: String) : ClipRecognition
+    data object NoMatch : ClipRecognition
+    data class Error(val message: String) : ClipRecognition
+}
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -27,6 +41,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val sensitivity: StateFlow<Float> = SettingsStore.sensitivity
     val batteryDrainPerHour: StateFlow<Float?> = BeatMatcherState.batteryDrainPerHour
     val powerSaving: StateFlow<Boolean> = BeatMatcherState.powerSaving
+
+    val acrHost: StateFlow<String> = SettingsStore.acrHost
+    val acrKey: StateFlow<String> = SettingsStore.acrKey
+    val acrSecret: StateFlow<String> = SettingsStore.acrSecret
+    val acrConfigured: StateFlow<Boolean> = SettingsStore.acrConfigured
+
+    private val _recognition = MutableStateFlow<ClipRecognition>(ClipRecognition.Idle)
+    val recognition: StateFlow<ClipRecognition> = _recognition.asStateFlow()
 
     private val _hasAudioPermission = MutableStateFlow(false)
     val hasAudioPermission: StateFlow<Boolean> = _hasAudioPermission.asStateFlow()
@@ -79,5 +101,46 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun rejectClip(clip: ClipItem) {
         SettingsStore.recordReject()
         clipRepository.deleteClip(clip.name)
+    }
+
+    fun setAcrCredentials(host: String, key: String, secret: String) {
+        SettingsStore.setAcrCredentials(host, key, secret)
+    }
+
+    /** Identify a saved clip via ACRCloud (works even after the song has stopped). */
+    fun recognizeClip(clip: ClipItem) {
+        _recognition.value = ClipRecognition.Loading
+        viewModelScope.launch {
+            val bytes = withContext(Dispatchers.IO) {
+                clipRepository.getClipFile(clip.name)?.readBytes()
+            }
+            if (bytes == null) {
+                _recognition.value = ClipRecognition.Error("Clip not found")
+                return@launch
+            }
+            val outcome = AcrCloudClient.recognize(
+                host = SettingsStore.acrHost.value,
+                accessKey = SettingsStore.acrKey.value,
+                accessSecret = SettingsStore.acrSecret.value,
+                audio = bytes
+            )
+            _recognition.value = when (outcome) {
+                is AcrOutcome.Success -> {
+                    withContext(Dispatchers.IO) {
+                        clipRepository.writeMeta(clip.name, outcome.title, outcome.artist)
+                    }
+                    BeatMatcherState.notifyClipsChanged()
+                    ClipRecognition.Done(outcome.artist, outcome.title)
+                }
+                AcrOutcome.NoMatch -> ClipRecognition.NoMatch
+                AcrOutcome.NotConfigured ->
+                    ClipRecognition.Error("Add ACRCloud credentials in Settings")
+                is AcrOutcome.Error -> ClipRecognition.Error(outcome.message)
+            }
+        }
+    }
+
+    fun clearRecognition() {
+        _recognition.value = ClipRecognition.Idle
     }
 }

--- a/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
@@ -2,13 +2,7 @@ package com.hereliesaz.mademedance
 
 import android.Manifest
 import android.app.Application
-import android.content.ComponentName
-import android.content.Context
-import android.content.Intent
-import android.content.ServiceConnection
 import android.content.pm.PackageManager
-import android.hardware.Sensor
-import android.hardware.SensorManager
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import com.hereliesaz.mademedance.data.ClipRepository
@@ -34,11 +28,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val hasNotificationPermission: StateFlow<Boolean> = _hasNotificationPermission.asStateFlow()
 
     val clipRepository = ClipRepository(application.getExternalFilesDir(null))
-
-    val hasGyroscope: Boolean = run {
-        val sm = application.getSystemService(Context.SENSOR_SERVICE) as SensorManager
-        sm.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null
-    }
 
     init {
         refreshPermissionState()

--- a/app/src/main/java/com/hereliesaz/mademedance/RhythmDetector.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/RhythmDetector.kt
@@ -6,22 +6,27 @@ import org.apache.commons.math3.transform.DftNormalization
 import org.apache.commons.math3.transform.FastFourierTransformer
 import org.apache.commons.math3.transform.TransformType
 import java.util.*
+import kotlin.math.sqrt
 
 class RhythmDetector {
 
-    private val windowSize = 128 // Increased window size for better frequency resolution
-    private val dataQueue = ArrayDeque<Pair<Long, FloatArray>>(windowSize)
-    private val magnitudeThreshold = 20.0 // Adjusted threshold for significant movement
+    private val windowSize = 128
+    private val dataQueue = ArrayDeque<Pair<Long, Double>>(windowSize)
+
+    // Threshold on the dominant FFT bin of the gravity-removed accelerometer
+    // magnitude (m/s²). Empirical — needs on-device tuning; too high and gentle
+    // dancing won't register, too low and walking/jitter triggers it.
+    private val energyThreshold = 50.0
 
     fun getMovementBpm(event: SensorEvent): Float? {
         val timestamp = event.timestamp
-        val gyroValues = event.values
+        val v = event.values
+        val magnitude = sqrt((v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).toDouble())
 
-        dataQueue.addLast(Pair(timestamp, gyroValues))
+        dataQueue.addLast(Pair(timestamp, magnitude))
         if (dataQueue.size > windowSize) {
             dataQueue.removeFirst()
         }
-
         if (dataQueue.size < windowSize) {
             return null // Not enough data yet
         }
@@ -29,43 +34,51 @@ class RhythmDetector {
         val firstTimestamp = dataQueue.first.first
         val lastTimestamp = dataQueue.last.first
         val durationNanos = lastTimestamp - firstTimestamp
-        if (durationNanos == 0L) return null
+        if (durationNanos <= 0L) return null
 
-        // Calculate the sampling rate in Hz
-        val sampleRate = (windowSize.toDouble() / durationNanos) * 1_000_000_000.0
+        // windowSize samples span (windowSize - 1) sampling intervals
+        val sampleRate = (windowSize - 1).toDouble() / durationNanos * 1_000_000_000.0
 
-        // We'll analyze the magnitude of the gyroscope vector
-        val magnitudes = dataQueue.map {
-            val x = it.second[0]
-            val y = it.second[1]
-            val z = it.second[2]
-            Math.sqrt((x * x + y * y + z * z).toDouble())
-        }
-
+        // Subtract the mean so gravity (a large DC offset on the accelerometer)
+        // doesn't dominate; what's left is the oscillation from body movement.
+        val mean = dataQueue.sumOf { it.second } / windowSize
         val transformer = FastFourierTransformer(DftNormalization.STANDARD)
-        val complexData = magnitudes.map { Complex(it) }.toTypedArray()
+        val complexData = dataQueue.map { Complex(it.second - mean) }.toTypedArray()
         val fftResults = transformer.transform(complexData, TransformType.FORWARD)
 
         var maxMagnitude = -1.0
-        var dominantFrequencyIndex = 0
-        // Iterate up to half the window size (Nyquist theorem)
+        var dominantBin = 0
+        // Iterate up to half the window size (Nyquist), skipping the DC bin
         for (i in 1 until windowSize / 2) {
             val mag = fftResults[i].abs()
             if (mag > maxMagnitude) {
                 maxMagnitude = mag
-                dominantFrequencyIndex = i
+                dominantBin = i
             }
         }
 
-        if (maxMagnitude > magnitudeThreshold) {
-            val dominantFrequencyHz = dominantFrequencyIndex * sampleRate / windowSize
-            // Convert to BPM, but only for a reasonable dance tempo range (e.g., 60-180 BPM)
-            val bpm = (dominantFrequencyHz * 60).toFloat()
-            if (bpm in 60f..180f) {
-                return bpm
-            }
+        if (dominantBin == 0 || maxMagnitude <= energyThreshold) {
+            return null
         }
 
-        return null
+        // Each bin is ~sampleRate/windowSize Hz wide (≈23 BPM here), far coarser
+        // than the 5 BPM match tolerance. Parabolic interpolation around the peak
+        // recovers a sub-bin frequency estimate.
+        val refinedBin = parabolicPeak(fftResults, dominantBin)
+        val dominantFrequencyHz = refinedBin * sampleRate / windowSize
+        val bpm = (dominantFrequencyHz * 60).toFloat()
+
+        return if (bpm in 60f..180f) bpm else null
+    }
+
+    private fun parabolicPeak(fft: Array<Complex>, k: Int): Double {
+        if (k <= 0 || k >= fft.size / 2 - 1) return k.toDouble()
+        val alpha = fft[k - 1].abs()
+        val beta = fft[k].abs()
+        val gamma = fft[k + 1].abs()
+        val denom = alpha - 2 * beta + gamma
+        if (denom == 0.0) return k.toDouble()
+        val offset = 0.5 * (alpha - gamma) / denom
+        return k + offset
     }
 }

--- a/app/src/main/java/com/hereliesaz/mademedance/RhythmDetector.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/RhythmDetector.kt
@@ -10,13 +10,27 @@ import kotlin.math.sqrt
 
 class RhythmDetector {
 
+    companion object {
+        // Sensitivity 0 demands vigorous movement; 1 triggers on gentle motion.
+        // These m/s² endpoints are empirical and need on-device tuning.
+        private const val THRESHOLD_AT_MIN_SENSITIVITY = 120.0
+        private const val THRESHOLD_AT_MAX_SENSITIVITY = 15.0
+
+        fun thresholdForSensitivity(sensitivity: Float): Double {
+            val s = sensitivity.coerceIn(0f, 1f).toDouble()
+            return THRESHOLD_AT_MIN_SENSITIVITY +
+                s * (THRESHOLD_AT_MAX_SENSITIVITY - THRESHOLD_AT_MIN_SENSITIVITY)
+        }
+    }
+
     private val windowSize = 128
     private val dataQueue = ArrayDeque<Pair<Long, Double>>(windowSize)
 
     // Threshold on the dominant FFT bin of the gravity-removed accelerometer
-    // magnitude (m/s²). Empirical — needs on-device tuning; too high and gentle
-    // dancing won't register, too low and walking/jitter triggers it.
-    private val energyThreshold = 50.0
+    // magnitude (m/s²). Driven by the user's sensitivity setting; updated live
+    // by the service as the knob, ratings, or battery pressure change it.
+    @Volatile
+    var energyThreshold: Double = thresholdForSensitivity(0.5f)
 
     fun getMovementBpm(event: SensorEvent): Float? {
         val timestamp = event.timestamp

--- a/app/src/main/java/com/hereliesaz/mademedance/data/ClipRepository.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/data/ClipRepository.kt
@@ -8,11 +8,25 @@ import java.util.Locale
 data class ClipItem(
     val name: String,
     val file: File,
-    val timestamp: Long
+    val timestamp: Long,
+    val artist: String? = null,
+    val title: String? = null
 ) {
+    val knownSong: Boolean get() = !title.isNullOrBlank()
+
     val formattedDate: String
         get() = SimpleDateFormat("MMM d, yyyy h:mm a", Locale.getDefault())
             .format(Date(timestamp))
+}
+
+/** Sidecar that records an identified song next to its clip. */
+private fun metaFileFor(clipFile: File): File = File(clipFile.parentFile, clipFile.name + ".meta")
+
+/** Write a clip's identified song. Usable without a [ClipRepository] instance (e.g. the service). */
+fun writeClipMeta(clipFile: File, title: String, artist: String?) {
+    try {
+        metaFileFor(clipFile).writeText("$title\n${artist ?: ""}")
+    } catch (_: Exception) { /* best-effort */ }
 }
 
 class ClipRepository(private val storageDir: File?) {
@@ -21,8 +35,14 @@ class ClipRepository(private val storageDir: File?) {
         val dir = storageDir ?: return emptyList()
         return dir.listFiles { file -> file.name.endsWith(".mmd") }
             ?.map { file ->
-                val timestamp = extractTimestamp(file.name)
-                ClipItem(name = file.name, file = file, timestamp = timestamp)
+                val (title, artist) = readMeta(file)
+                ClipItem(
+                    name = file.name,
+                    file = file,
+                    timestamp = extractTimestamp(file.name),
+                    artist = artist,
+                    title = title
+                )
             }
             ?.sortedByDescending { it.timestamp }
             ?: emptyList()
@@ -36,7 +56,27 @@ class ClipRepository(private val storageDir: File?) {
 
     fun deleteClip(clipName: String): Boolean {
         val file = getClipFile(clipName) ?: return false
+        metaFileFor(file).delete() // best-effort; ignore result
         return file.delete()
+    }
+
+    /** Returns (title, artist); either may be null when no sidecar exists. */
+    fun readMeta(clipFile: File): Pair<String?, String?> {
+        return try {
+            val meta = metaFileFor(clipFile)
+            if (!meta.exists()) return null to null
+            val lines = meta.readLines()
+            val title = lines.getOrNull(0)?.takeIf { it.isNotBlank() }
+            val artist = lines.getOrNull(1)?.takeIf { it.isNotBlank() }
+            title to artist
+        } catch (_: Exception) {
+            null to null
+        }
+    }
+
+    fun writeMeta(clipName: String, title: String, artist: String?) {
+        val file = getClipFile(clipName) ?: return
+        writeClipMeta(file, title, artist)
     }
 
     private fun extractTimestamp(fileName: String): Long {

--- a/app/src/main/java/com/hereliesaz/mademedance/identify/AcrCloudClient.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/identify/AcrCloudClient.kt
@@ -91,8 +91,11 @@ object AcrCloudClient {
             when (val statusCode = status?.optInt("code", -1) ?: -1) {
                 0 -> {
                     val music = json.optJSONObject("metadata")?.optJSONArray("music")
-                    val first = if (music != null && music.length() > 0) music.getJSONObject(0) else null
-                        ?: return AcrOutcome.NoMatch
+                    val first = if (music != null && music.length() > 0) {
+                        music.getJSONObject(0)
+                    } else {
+                        return AcrOutcome.NoMatch
+                    }
                     val title = first.optString("title").takeIf { it.isNotBlank() }
                         ?: return AcrOutcome.NoMatch
                     val artist = first.optJSONArray("artists")

--- a/app/src/main/java/com/hereliesaz/mademedance/identify/AcrCloudClient.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/identify/AcrCloudClient.kt
@@ -1,0 +1,144 @@
+package com.hereliesaz.mademedance.identify
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import android.util.Base64
+
+sealed interface AcrOutcome {
+    data class Success(val artist: String?, val title: String) : AcrOutcome
+    data object NoMatch : AcrOutcome
+    data object NotConfigured : AcrOutcome
+    data class Error(val message: String) : AcrOutcome
+}
+
+/**
+ * Recognizes a recorded audio clip against ACRCloud's identify API (free
+ * developer tier). Unlike the live-listening recognizer apps, this works on
+ * the saved clip — the whole point being to identify a song after it has
+ * stopped playing.
+ *
+ * Credentials are the user's own (host / access key / access secret), entered
+ * in Settings; we ship none.
+ */
+object AcrCloudClient {
+
+    suspend fun recognize(
+        host: String,
+        accessKey: String,
+        accessSecret: String,
+        audio: ByteArray
+    ): AcrOutcome = withContext(Dispatchers.IO) {
+        if (host.isBlank() || accessKey.isBlank() || accessSecret.isBlank()) {
+            return@withContext AcrOutcome.NotConfigured
+        }
+        try {
+            val endpoint = "https://$host/v1/identify"
+            val dataType = "audio"
+            val signatureVersion = "1"
+            val timestamp = (System.currentTimeMillis() / 1000).toString()
+
+            val stringToSign =
+                "POST\n/v1/identify\n$accessKey\n$dataType\n$signatureVersion\n$timestamp"
+            val signature = hmacSha1Base64(stringToSign, accessSecret)
+
+            val boundary = "----mmdBoundary${System.currentTimeMillis()}"
+            val body = buildMultipart(
+                boundary = boundary,
+                fields = linkedMapOf(
+                    "access_key" to accessKey,
+                    "data_type" to dataType,
+                    "signature_version" to signatureVersion,
+                    "signature" to signature,
+                    "sample_bytes" to audio.size.toString(),
+                    "timestamp" to timestamp
+                ),
+                fileFieldName = "sample",
+                fileName = "sample.wav",
+                fileBytes = audio
+            )
+
+            val conn = (URL(endpoint).openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"
+                doOutput = true
+                connectTimeout = 15_000
+                readTimeout = 20_000
+                setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
+            }
+            conn.outputStream.use { it.write(body) }
+
+            val code = conn.responseCode
+            val stream = if (code in 200..299) conn.inputStream else conn.errorStream
+            val text = stream?.bufferedReader()?.use { it.readText() } ?: ""
+            conn.disconnect()
+
+            parseResponse(text)
+        } catch (e: Exception) {
+            AcrOutcome.Error(e.message ?: "Network error")
+        }
+    }
+
+    private fun parseResponse(text: String): AcrOutcome {
+        if (text.isBlank()) return AcrOutcome.Error("Empty response")
+        return try {
+            val json = JSONObject(text)
+            val status = json.optJSONObject("status")
+            when (val statusCode = status?.optInt("code", -1) ?: -1) {
+                0 -> {
+                    val music = json.optJSONObject("metadata")?.optJSONArray("music")
+                    val first = if (music != null && music.length() > 0) music.getJSONObject(0) else null
+                        ?: return AcrOutcome.NoMatch
+                    val title = first.optString("title").takeIf { it.isNotBlank() }
+                        ?: return AcrOutcome.NoMatch
+                    val artist = first.optJSONArray("artists")
+                        ?.optJSONObject(0)?.optString("name")?.takeIf { it.isNotBlank() }
+                    AcrOutcome.Success(artist, title)
+                }
+                1001 -> AcrOutcome.NoMatch
+                else -> AcrOutcome.Error(status?.optString("msg")?.takeIf { it.isNotBlank() }
+                    ?: "ACRCloud error $statusCode")
+            }
+        } catch (e: Exception) {
+            AcrOutcome.Error("Bad response")
+        }
+    }
+
+    private fun hmacSha1Base64(data: String, secret: String): String {
+        val mac = Mac.getInstance("HmacSHA1")
+        mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA1"))
+        val raw = mac.doFinal(data.toByteArray(Charsets.UTF_8))
+        return Base64.encodeToString(raw, Base64.NO_WRAP)
+    }
+
+    private fun buildMultipart(
+        boundary: String,
+        fields: Map<String, String>,
+        fileFieldName: String,
+        fileName: String,
+        fileBytes: ByteArray
+    ): ByteArray {
+        val out = ByteArrayOutputStream()
+        val dashes = "--"
+        val crlf = "\r\n"
+        for ((name, value) in fields) {
+            out.write("$dashes$boundary$crlf".toByteArray())
+            out.write("Content-Disposition: form-data; name=\"$name\"$crlf$crlf".toByteArray())
+            out.write("$value$crlf".toByteArray())
+        }
+        out.write("$dashes$boundary$crlf".toByteArray())
+        out.write(
+            ("Content-Disposition: form-data; name=\"$fileFieldName\"; filename=\"$fileName\"$crlf")
+                .toByteArray()
+        )
+        out.write("Content-Type: application/octet-stream$crlf$crlf".toByteArray())
+        out.write(fileBytes)
+        out.write(crlf.toByteArray())
+        out.write("$dashes$boundary$dashes$crlf".toByteArray())
+        return out.toByteArray()
+    }
+}

--- a/app/src/main/java/com/hereliesaz/mademedance/identify/NowPlayingListenerService.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/identify/NowPlayingListenerService.kt
@@ -1,0 +1,10 @@
+package com.hereliesaz.mademedance.identify
+
+import android.service.notification.NotificationListenerService
+
+/**
+ * Exists only so the user can grant notification access, which is what unlocks
+ * [android.media.session.MediaSessionManager.getActiveSessions] for reading the
+ * device's currently-playing media. We don't process notifications here.
+ */
+class NowPlayingListenerService : NotificationListenerService()

--- a/app/src/main/java/com/hereliesaz/mademedance/identify/SongIdentifier.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/identify/SongIdentifier.kt
@@ -41,6 +41,12 @@ object SongIdentifier {
         return IdentifyResult.NoRecognizer
     }
 
+    /** Side-effect-free read of the device's currently-playing media, if any. */
+    fun currentlyPlaying(context: Context): IdentifyResult.NowPlaying? = readNowPlaying(context)
+
+    /** Launch the most-preferred installed recognizer; returns its label or null. */
+    fun launchAnyRecognizer(context: Context): String? = launchFirstRecognizer(context)
+
     fun hasNotificationAccess(context: Context): Boolean {
         val enabled = Settings.Secure.getString(
             context.contentResolver, "enabled_notification_listeners"

--- a/app/src/main/java/com/hereliesaz/mademedance/identify/SongIdentifier.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/identify/SongIdentifier.kt
@@ -1,0 +1,125 @@
+package com.hereliesaz.mademedance.identify
+
+import android.app.SearchManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.media.MediaMetadata
+import android.media.session.MediaSessionManager
+import android.media.session.PlaybackState
+import android.net.Uri
+import android.provider.Settings
+
+sealed interface IdentifyResult {
+    data class NowPlaying(val artist: String?, val title: String) : IdentifyResult
+    data class OpenedApp(val label: String) : IdentifyResult
+    data object NoRecognizer : IdentifyResult
+}
+
+/**
+ * Free song identification, no API key. The chain:
+ *  1. If media is playing on the device, read its title/artist directly.
+ *  2. Otherwise launch the most preferred recognizer app installed (Google
+ *     first), which listens live.
+ *  3. If none is installed, open a web search and tell the user to install one.
+ */
+object SongIdentifier {
+
+    // Ordered preference — Google's Sound Search first, then the usual suspects.
+    private val recognizerPackages = listOf(
+        "com.google.android.googlequicksearchbox", // Google app (Sound Search / Now Playing)
+        "com.shazam.android",
+        "com.melodis.midomiMusicIdentifier.freemium", // SoundHound (free)
+        "com.melodis.midomiMusicIdentifier",          // SoundHound
+        "com.musixmatch.android.lyrify"
+    )
+
+    fun identify(context: Context): IdentifyResult {
+        readNowPlaying(context)?.let { return it }
+        launchFirstRecognizer(context)?.let { return IdentifyResult.OpenedApp(it) }
+        openWebSearch(context, "what song is this")
+        return IdentifyResult.NoRecognizer
+    }
+
+    fun hasNotificationAccess(context: Context): Boolean {
+        val enabled = Settings.Secure.getString(
+            context.contentResolver, "enabled_notification_listeners"
+        ) ?: return false
+        val me = context.packageName
+        return enabled.split(":").any { it.contains(me) }
+    }
+
+    fun openNotificationAccessSettings(context: Context) {
+        context.startActivity(
+            Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+    }
+
+    /** Web search for an actually-known song — useful, unlike a blind "what is this song". */
+    fun searchForKnownSong(context: Context, artist: String?, title: String) {
+        val query = listOfNotNull(artist?.takeIf { it.isNotBlank() }, title).joinToString(" ")
+        openWebSearch(context, query)
+    }
+
+    private fun readNowPlaying(context: Context): IdentifyResult.NowPlaying? {
+        if (!hasNotificationAccess(context)) return null
+        return try {
+            val msm = context.getSystemService(Context.MEDIA_SESSION_SERVICE) as? MediaSessionManager
+                ?: return null
+            val component = ComponentName(context, NowPlayingListenerService::class.java)
+            for (controller in msm.getActiveSessions(component)) {
+                if (controller.playbackState?.state != PlaybackState.STATE_PLAYING) continue
+                val metadata = controller.metadata ?: continue
+                val title = metadata.getString(MediaMetadata.METADATA_KEY_TITLE)
+                if (!title.isNullOrBlank()) {
+                    val artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST)
+                        ?: metadata.getString(MediaMetadata.METADATA_KEY_ALBUM_ARTIST)
+                    return IdentifyResult.NowPlaying(artist?.takeIf { it.isNotBlank() }, title)
+                }
+            }
+            null
+        } catch (_: SecurityException) {
+            null
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun launchFirstRecognizer(context: Context): String? {
+        val pm = context.packageManager
+        for (pkg in recognizerPackages) {
+            val launch = pm.getLaunchIntentForPackage(pkg)
+                ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) ?: continue
+            try {
+                context.startActivity(launch)
+                return appLabel(context, pkg)
+            } catch (_: Exception) {
+                // Try the next candidate.
+            }
+        }
+        return null
+    }
+
+    private fun appLabel(context: Context, pkg: String): String = try {
+        val pm = context.packageManager
+        pm.getApplicationLabel(pm.getApplicationInfo(pkg, 0)).toString()
+    } catch (_: Exception) {
+        pkg
+    }
+
+    private fun openWebSearch(context: Context, query: String) {
+        val search = Intent(Intent.ACTION_WEB_SEARCH).apply {
+            putExtra(SearchManager.QUERY, query)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        if (search.resolveActivity(context.packageManager) != null) {
+            context.startActivity(search)
+        } else {
+            val uri = Uri.parse("https://www.google.com/search?q=" + Uri.encode(query))
+            context.startActivity(
+                Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/hereliesaz/mademedance/sensor/MovementTracker.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/sensor/MovementTracker.kt
@@ -12,16 +12,16 @@ import kotlinx.coroutines.flow.asStateFlow
 class MovementTracker(private val sensorManager: SensorManager) : SensorEventListener {
 
     private val rhythmDetector = RhythmDetector()
-    private val gyroscopeSensor: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
+    private val accelerometerSensor: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
 
-    val isAvailable: Boolean = gyroscopeSensor != null
+    val isAvailable: Boolean = accelerometerSensor != null
 
     private val _bpm = MutableStateFlow<Float?>(null)
     val bpm: StateFlow<Float?> = _bpm.asStateFlow()
 
     fun start() {
-        gyroscopeSensor?.also { gyro ->
-            sensorManager.registerListener(this, gyro, SensorManager.SENSOR_DELAY_GAME)
+        accelerometerSensor?.also { sensor ->
+            sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_GAME)
         }
     }
 
@@ -30,7 +30,7 @@ class MovementTracker(private val sensorManager: SensorManager) : SensorEventLis
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
-        if (event?.sensor?.type == Sensor.TYPE_GYROSCOPE) {
+        if (event?.sensor?.type == Sensor.TYPE_ACCELEROMETER) {
             _bpm.value = rhythmDetector.getMovementBpm(event)
         }
     }

--- a/app/src/main/java/com/hereliesaz/mademedance/sensor/MovementTracker.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/sensor/MovementTracker.kt
@@ -19,6 +19,10 @@ class MovementTracker(private val sensorManager: SensorManager) : SensorEventLis
     private val _bpm = MutableStateFlow<Float?>(null)
     val bpm: StateFlow<Float?> = _bpm.asStateFlow()
 
+    fun setEnergyThreshold(value: Double) {
+        rhythmDetector.energyThreshold = value
+    }
+
     fun start() {
         accelerometerSensor?.also { sensor ->
             sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_GAME)

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
@@ -133,7 +133,7 @@ class BeatMatcherService : Service() {
                 }
             }
         } else {
-            BeatMatcherState.setSystemStatus("No gyroscope sensor on this device.")
+            BeatMatcherState.setSystemStatus("No motion sensor on this device.")
         }
 
         audioJob = scope.launch {

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.hardware.SensorManager
+import android.os.BatteryManager
 import android.os.Build
 import android.os.IBinder
 import android.os.PowerManager
@@ -22,7 +23,9 @@ import androidx.core.content.ContextCompat
 import com.hereliesaz.mademedance.AudioBpmDetector
 import com.hereliesaz.mademedance.MainActivity
 import com.hereliesaz.mademedance.R
+import com.hereliesaz.mademedance.RhythmDetector
 import com.hereliesaz.mademedance.sensor.MovementTracker
+import com.hereliesaz.mademedance.settings.SettingsStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -33,6 +36,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.io.File
 import java.io.IOException
+import java.util.ArrayDeque
 import kotlin.math.abs
 
 class BeatMatcherService : Service() {
@@ -49,6 +53,20 @@ class BeatMatcherService : Service() {
         private const val BPM_MATCH_THRESHOLD = 5.0
         private const val NOTIFICATION_UPDATE_INTERVAL_MS = 1000L
 
+        // Battery-driven power saving. Drain below DRAIN_OK_PER_HOUR is fine;
+        // at/above DRAIN_HIGH_PER_HOUR we apply the full backoff. Values are
+        // %/hour and empirical.
+        private const val BATTERY_SAMPLE_INTERVAL_MS = 60_000L
+        private const val BATTERY_WINDOW_MS = 10 * 60 * 1000L
+        private const val DRAIN_OK_PER_HOUR = 8f
+        private const val DRAIN_HIGH_PER_HOUR = 25f
+        private const val MAX_BATTERY_SENSITIVITY_PENALTY = 0.4f
+
+        // Audio processing cadence stretches under power saving — the real
+        // battery lever, since the mic + FFT loop dominates consumption.
+        private const val AUDIO_INTERVAL_MIN_MS = 100L
+        private const val AUDIO_INTERVAL_MAX_MS = 400L
+
         fun start(context: Context) {
             val intent = Intent(context, BeatMatcherService::class.java).setAction(ACTION_START)
             ContextCompat.startForegroundService(context, intent)
@@ -64,11 +82,21 @@ class BeatMatcherService : Service() {
     private var audioJob: Job? = null
     private var sensorJob: Job? = null
     private var notificationJob: Job? = null
+    private var batteryJob: Job? = null
+    private var sensitivityJob: Job? = null
 
     private lateinit var audioBpmDetector: AudioBpmDetector
     private lateinit var movementTracker: MovementTracker
     private var wakeLock: PowerManager.WakeLock? = null
     private var matchCounter = 0
+
+    private val batterySamples = ArrayDeque<Pair<Long, Float>>()
+
+    @Volatile
+    private var batteryPenalty = 0f
+
+    @Volatile
+    private var audioIntervalMs = AUDIO_INTERVAL_MIN_MS
 
     private val vibrator: Vibrator? by lazy {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -83,6 +111,7 @@ class BeatMatcherService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        SettingsStore.init(this)
         createNotificationChannels()
         val sensorManager = getSystemService(Context.SENSOR_SERVICE) as SensorManager
         movementTracker = MovementTracker(sensorManager)
@@ -144,7 +173,7 @@ class BeatMatcherService : Service() {
                     BeatMatcherState.setAudioBpm(bpm)
                     checkForMatch()
                 }
-                delay(100)
+                delay(audioIntervalMs)
             }
         }
 
@@ -154,6 +183,63 @@ class BeatMatcherService : Service() {
                 updateForegroundNotification()
             }
         }
+
+        // React to the user moving the sensitivity knob (or a rating lowering it).
+        sensitivityJob = scope.launch {
+            SettingsStore.sensitivity.collect { applyBackoff() }
+        }
+
+        batterySamples.clear()
+        batteryJob = scope.launch {
+            while (isActive) {
+                sampleBattery()
+                delay(BATTERY_SAMPLE_INTERVAL_MS)
+            }
+        }
+    }
+
+    /**
+     * Combine the persisted sensitivity with the current battery penalty
+     * (both can only lower it) into the effective threshold and processing
+     * cadence, then push them to the detector + audio loop.
+     */
+    private fun applyBackoff() {
+        val base = SettingsStore.sensitivity.value
+        val effective = (base - batteryPenalty).coerceIn(0f, 1f)
+        movementTracker.setEnergyThreshold(RhythmDetector.thresholdForSensitivity(effective))
+
+        val penaltyNorm = (batteryPenalty / MAX_BATTERY_SENSITIVITY_PENALTY).coerceIn(0f, 1f)
+        audioIntervalMs = AUDIO_INTERVAL_MIN_MS +
+            (penaltyNorm * (AUDIO_INTERVAL_MAX_MS - AUDIO_INTERVAL_MIN_MS)).toLong()
+
+        BeatMatcherState.setPowerSaving(batteryPenalty > 0f)
+    }
+
+    private fun sampleBattery() {
+        val bm = getSystemService(Context.BATTERY_SERVICE) as? BatteryManager ?: return
+        val pct = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+        if (pct !in 0..100) return
+
+        val now = System.currentTimeMillis()
+        batterySamples.addLast(now to pct.toFloat())
+        while (batterySamples.size > 1 && now - batterySamples.first.first > BATTERY_WINDOW_MS) {
+            batterySamples.removeFirst()
+        }
+
+        val oldest = batterySamples.first
+        val hours = (now - oldest.first) / 3_600_000.0
+        // Negative drain = charging; clamp to 0.
+        val drain = if (hours > 0.0) ((oldest.second - pct) / hours).toFloat().coerceAtLeast(0f) else null
+
+        batteryPenalty = if (drain == null) {
+            0f
+        } else {
+            val span = (DRAIN_HIGH_PER_HOUR - DRAIN_OK_PER_HOUR)
+            (((drain - DRAIN_OK_PER_HOUR) / span).coerceIn(0f, 1f)) * MAX_BATTERY_SENSITIVITY_PENALTY
+        }
+
+        BeatMatcherState.setBatteryDrainPerHour(drain)
+        applyBackoff()
     }
 
     private fun checkForMatch() {
@@ -199,12 +285,18 @@ class BeatMatcherService : Service() {
         audioJob?.cancel(); audioJob = null
         sensorJob?.cancel(); sensorJob = null
         notificationJob?.cancel(); notificationJob = null
+        batteryJob?.cancel(); batteryJob = null
+        sensitivityJob?.cancel(); sensitivityJob = null
         try { audioBpmDetector.stop() } catch (_: Exception) {}
         try { movementTracker.stop() } catch (_: Exception) {}
         releaseWakeLock()
+        batterySamples.clear()
+        batteryPenalty = 0f
         BeatMatcherState.setRunning(false)
         BeatMatcherState.setMovementBpm(null)
         BeatMatcherState.setAudioBpm(null)
+        BeatMatcherState.setBatteryDrainPerHour(null)
+        BeatMatcherState.setPowerSaving(false)
         BeatMatcherState.setSystemStatus("Service stopped.")
     }
 
@@ -289,11 +381,16 @@ class BeatMatcherService : Service() {
 
         val movement = BeatMatcherState.movementBpm.value
         val audio = BeatMatcherState.audioBpm.value
-        val title = "MadeMeDance is listening"
+        val drain = BeatMatcherState.batteryDrainPerHour.value
+        val powerSaving = BeatMatcherState.powerSaving.value
+        val title = if (powerSaving) "MadeMeDance (power-saving)" else "MadeMeDance is listening"
         val body = buildString {
             append(movement?.let { "You: ${"%.0f".format(it)} BPM" } ?: "You: -- BPM")
             append("   ")
             append(audio?.let { "Song: ${"%.0f".format(it)} BPM" } ?: "Song: -- BPM")
+            if (drain != null) {
+                append("   ~${"%.0f".format(drain)}%/hr")
+            }
         }
 
         return NotificationCompat.Builder(this, CHANNEL_STATUS)

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
@@ -53,6 +53,12 @@ class BeatMatcherService : Service() {
         private const val BPM_MATCH_THRESHOLD = 5.0
         private const val NOTIFICATION_UPDATE_INTERVAL_MS = 1000L
 
+        // The accelerometer (cheap) runs continuously; the mic (expensive,
+        // privacy-sensitive) only wakes while you're dancing and shuts off
+        // after this long without a detected movement BPM.
+        private const val MIC_IDLE_TIMEOUT_MS = 8_000L
+        private const val MIC_IDLE_CHECK_INTERVAL_MS = 2_000L
+
         // Battery-driven power saving. Drain below DRAIN_OK_PER_HOUR is fine;
         // at/above DRAIN_HIGH_PER_HOUR we apply the full backoff. Values are
         // %/hour and empirical.
@@ -84,11 +90,15 @@ class BeatMatcherService : Service() {
     private var notificationJob: Job? = null
     private var batteryJob: Job? = null
     private var sensitivityJob: Job? = null
+    private var micWatchdogJob: Job? = null
 
     private lateinit var audioBpmDetector: AudioBpmDetector
     private lateinit var movementTracker: MovementTracker
     private var wakeLock: PowerManager.WakeLock? = null
     private var matchCounter = 0
+
+    @Volatile
+    private var lastDanceMs = 0L
 
     private val batterySamples = ArrayDeque<Pair<Long, Float>>()
 
@@ -138,7 +148,7 @@ class BeatMatcherService : Service() {
         acquireWakeLock()
 
         BeatMatcherState.setRunning(true)
-        BeatMatcherState.setSystemStatus("Listening...")
+        BeatMatcherState.setSystemStatus("Starting…")
 
         val hasMic = ContextCompat.checkSelfPermission(
             this, Manifest.permission.RECORD_AUDIO
@@ -153,28 +163,31 @@ class BeatMatcherService : Service() {
 
         if (movementTracker.isAvailable) {
             movementTracker.start()
+            BeatMatcherState.setSystemStatus("Waiting for you to dance…")
             sensorJob = scope.launch {
                 movementTracker.bpm.collect { bpm ->
                     if (bpm != null) {
                         BeatMatcherState.setMovementBpm(bpm)
+                        lastDanceMs = System.currentTimeMillis()
+                        ensureAudioRunning()
                         checkForMatch()
+                    }
+                }
+            }
+            // Shut the mic back off once the dancing stops.
+            micWatchdogJob = scope.launch {
+                while (isActive) {
+                    delay(MIC_IDLE_CHECK_INTERVAL_MS)
+                    if (audioJob?.isActive == true &&
+                        System.currentTimeMillis() - lastDanceMs > MIC_IDLE_TIMEOUT_MS
+                    ) {
+                        stopAudio()
+                        BeatMatcherState.setSystemStatus("Waiting for you to dance…")
                     }
                 }
             }
         } else {
             BeatMatcherState.setSystemStatus("No motion sensor on this device.")
-        }
-
-        audioJob = scope.launch {
-            audioBpmDetector.start()
-            while (isActive) {
-                val bpm = audioBpmDetector.processAudio()
-                if (bpm != null) {
-                    BeatMatcherState.setAudioBpm(bpm)
-                    checkForMatch()
-                }
-                delay(audioIntervalMs)
-            }
         }
 
         notificationJob = scope.launch {
@@ -196,6 +209,32 @@ class BeatMatcherService : Service() {
                 delay(BATTERY_SAMPLE_INTERVAL_MS)
             }
         }
+    }
+
+    @Synchronized
+    private fun ensureAudioRunning() {
+        if (audioJob?.isActive == true) return
+        BeatMatcherState.setMicActive(true)
+        BeatMatcherState.setSystemStatus("Dancing detected — listening for the song…")
+        audioJob = scope.launch {
+            audioBpmDetector.start()
+            while (isActive) {
+                val bpm = audioBpmDetector.processAudio()
+                if (bpm != null) {
+                    BeatMatcherState.setAudioBpm(bpm)
+                    checkForMatch()
+                }
+                delay(audioIntervalMs)
+            }
+        }
+    }
+
+    @Synchronized
+    private fun stopAudio() {
+        audioJob?.cancel(); audioJob = null
+        try { audioBpmDetector.stop() } catch (_: Exception) {}
+        BeatMatcherState.setAudioBpm(null)
+        BeatMatcherState.setMicActive(false)
     }
 
     /**
@@ -282,19 +321,18 @@ class BeatMatcherService : Service() {
     }
 
     private fun stopWork() {
-        audioJob?.cancel(); audioJob = null
         sensorJob?.cancel(); sensorJob = null
+        micWatchdogJob?.cancel(); micWatchdogJob = null
         notificationJob?.cancel(); notificationJob = null
         batteryJob?.cancel(); batteryJob = null
         sensitivityJob?.cancel(); sensitivityJob = null
-        try { audioBpmDetector.stop() } catch (_: Exception) {}
+        stopAudio()
         try { movementTracker.stop() } catch (_: Exception) {}
         releaseWakeLock()
         batterySamples.clear()
         batteryPenalty = 0f
         BeatMatcherState.setRunning(false)
         BeatMatcherState.setMovementBpm(null)
-        BeatMatcherState.setAudioBpm(null)
         BeatMatcherState.setBatteryDrainPerHour(null)
         BeatMatcherState.setPowerSaving(false)
         BeatMatcherState.setSystemStatus("Service stopped.")
@@ -383,7 +421,12 @@ class BeatMatcherService : Service() {
         val audio = BeatMatcherState.audioBpm.value
         val drain = BeatMatcherState.batteryDrainPerHour.value
         val powerSaving = BeatMatcherState.powerSaving.value
-        val title = if (powerSaving) "MadeMeDance (power-saving)" else "MadeMeDance is listening"
+        val base = if (BeatMatcherState.micActive.value) {
+            "Listening for the song"
+        } else {
+            "Watching for dancing"
+        }
+        val title = if (powerSaving) "$base (power-saving)" else base
         val body = buildString {
             append(movement?.let { "You: ${"%.0f".format(it)} BPM" } ?: "You: -- BPM")
             append("   ")

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
@@ -24,6 +24,9 @@ import com.hereliesaz.mademedance.AudioBpmDetector
 import com.hereliesaz.mademedance.MainActivity
 import com.hereliesaz.mademedance.R
 import com.hereliesaz.mademedance.RhythmDetector
+import com.hereliesaz.mademedance.data.writeClipMeta
+import com.hereliesaz.mademedance.identify.IdentifyResult
+import com.hereliesaz.mademedance.identify.SongIdentifier
 import com.hereliesaz.mademedance.sensor.MovementTracker
 import com.hereliesaz.mademedance.settings.SettingsStore
 import kotlinx.coroutines.CoroutineScope
@@ -291,7 +294,13 @@ class BeatMatcherService : Service() {
             BeatMatcherState.setMovementBpm(null)
             BeatMatcherState.setAudioBpm(null)
             if (savedFile != null) {
-                postMatchNotification()
+                // The music is live right now, so capture what's playing and
+                // remember it with the clip (works when it plays through the phone).
+                val nowPlaying = SongIdentifier.currentlyPlaying(this)
+                if (nowPlaying != null) {
+                    writeClipMeta(savedFile, nowPlaying.title, nowPlaying.artist)
+                }
+                postMatchNotification(nowPlaying)
                 BeatMatcherState.notifyClipsChanged()
             }
             updateForegroundNotification()
@@ -449,7 +458,7 @@ class BeatMatcherService : Service() {
             .build()
     }
 
-    private fun postMatchNotification() {
+    private fun postMatchNotification(nowPlaying: IdentifyResult.NowPlaying?) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
             != PackageManager.PERMISSION_GRANTED
@@ -462,25 +471,32 @@ class BeatMatcherService : Service() {
                 .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
-        val identify = PendingIntent.getActivity(
-            this, 101,
-            Intent(this, MainActivity::class.java)
-                .putExtra(MainActivity.EXTRA_IDENTIFY, true)
-                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        )
 
-        val notification = NotificationCompat.Builder(this, CHANNEL_MATCHES)
+        val builder = NotificationCompat.Builder(this, CHANNEL_MATCHES)
             .setSmallIcon(R.mipmap.ic_launcher)
-            .setContentTitle("You're dancing to something!")
-            .setContentText("15 s snippet saved — tap Identify to find the song.")
             .setContentIntent(openClips)
             .setAutoCancel(true)
-            .addAction(0, "Identify", identify)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .build()
+
+        if (nowPlaying != null) {
+            // We already know the song — no need to offer identification.
+            val song = listOfNotNull(nowPlaying.artist, nowPlaying.title).joinToString(" — ")
+            builder.setContentTitle("You're dancing to $song")
+                .setContentText("Saved — tap to view your clips.")
+        } else {
+            val identify = PendingIntent.getActivity(
+                this, 101,
+                Intent(this, MainActivity::class.java)
+                    .putExtra(MainActivity.EXTRA_IDENTIFY, true)
+                    .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            builder.setContentTitle("You're dancing to something!")
+                .setContentText("15 s snippet saved — tap Identify to find the song.")
+                .addAction(0, "Identify", identify)
+        }
 
         NotificationManagerCompat.from(this)
-            .notify(NOTIFICATION_ID_MATCH_BASE + (matchCounter++), notification)
+            .notify(NOTIFICATION_ID_MATCH_BASE + (matchCounter++), builder.build())
     }
 }

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
@@ -464,9 +464,9 @@ class BeatMatcherService : Service() {
         )
         val identify = PendingIntent.getActivity(
             this, 101,
-            Intent(android.content.Intent.ACTION_WEB_SEARCH)
-                .putExtra(android.app.SearchManager.QUERY, "what is this song")
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            Intent(this, MainActivity::class.java)
+                .putExtra(MainActivity.EXTRA_IDENTIFY, true)
+                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherState.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherState.kt
@@ -33,8 +33,12 @@ object BeatMatcherState {
     private val _powerSaving = MutableStateFlow(false)
     val powerSaving: StateFlow<Boolean> = _powerSaving.asStateFlow()
 
+    private val _micActive = MutableStateFlow(false)
+    val micActive: StateFlow<Boolean> = _micActive.asStateFlow()
+
     internal fun setBatteryDrainPerHour(drain: Float?) { _batteryDrainPerHour.value = drain }
     internal fun setPowerSaving(saving: Boolean) { _powerSaving.value = saving }
+    internal fun setMicActive(active: Boolean) { _micActive.value = active }
 
     internal fun setRunning(running: Boolean) { _isRunning.value = running }
     internal fun setMovementBpm(bpm: Float?) {

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherState.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherState.kt
@@ -27,6 +27,15 @@ object BeatMatcherState {
     private val _clipsChanged = MutableStateFlow(0)
     val clipsChanged: StateFlow<Int> = _clipsChanged.asStateFlow()
 
+    private val _batteryDrainPerHour = MutableStateFlow<Float?>(null)
+    val batteryDrainPerHour: StateFlow<Float?> = _batteryDrainPerHour.asStateFlow()
+
+    private val _powerSaving = MutableStateFlow(false)
+    val powerSaving: StateFlow<Boolean> = _powerSaving.asStateFlow()
+
+    internal fun setBatteryDrainPerHour(drain: Float?) { _batteryDrainPerHour.value = drain }
+    internal fun setPowerSaving(saving: Boolean) { _powerSaving.value = saving }
+
     internal fun setRunning(running: Boolean) { _isRunning.value = running }
     internal fun setMovementBpm(bpm: Float?) {
         _movementBpm.value = bpm

--- a/app/src/main/java/com/hereliesaz/mademedance/settings/SettingsStore.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/settings/SettingsStore.kt
@@ -1,0 +1,53 @@
+package com.hereliesaz.mademedance.settings
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Single source of truth for the user-tunable movement sensitivity.
+ *
+ * The same persisted value backs the manual knob and the auto-tuner. Per the
+ * "one-way conservative" rule, automatic adjustments only ever *lower*
+ * sensitivity (a rejected clip means the detector was too twitchy); the user
+ * is the only one who raises it back up via the knob.
+ */
+object SettingsStore {
+
+    private const val PREFS = "mmd_settings"
+    private const val KEY_SENSITIVITY = "sensitivity"
+    private const val DEFAULT_SENSITIVITY = 0.5f
+
+    // How far one rejected clip pulls sensitivity down.
+    private const val REJECT_STEP = 0.08f
+
+    private var prefs: SharedPreferences? = null
+
+    private val _sensitivity = MutableStateFlow(DEFAULT_SENSITIVITY)
+    val sensitivity: StateFlow<Float> = _sensitivity.asStateFlow()
+
+    fun init(context: Context) {
+        if (prefs != null) return
+        prefs = context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE).also {
+            _sensitivity.value = it.getFloat(KEY_SENSITIVITY, DEFAULT_SENSITIVITY)
+        }
+    }
+
+    fun setSensitivity(value: Float) {
+        val clamped = value.coerceIn(0f, 1f)
+        _sensitivity.value = clamped
+        prefs?.edit()?.putFloat(KEY_SENSITIVITY, clamped)?.apply()
+    }
+
+    /** A false trigger: back the detector off. */
+    fun recordReject() {
+        setSensitivity(_sensitivity.value - REJECT_STEP)
+    }
+
+    /** A good catch: confirms the current setting. Never auto-raises sensitivity. */
+    fun recordAccept() {
+        // One-way conservative — intentionally a no-op on the threshold.
+    }
+}

--- a/app/src/main/java/com/hereliesaz/mademedance/settings/SettingsStore.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/settings/SettingsStore.kt
@@ -2,37 +2,79 @@ package com.hereliesaz.mademedance.settings
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * Single source of truth for the user-tunable movement sensitivity.
+ * Single source of truth for user settings.
  *
- * The same persisted value backs the manual knob and the auto-tuner. Per the
- * "one-way conservative" rule, automatic adjustments only ever *lower*
- * sensitivity (a rejected clip means the detector was too twitchy); the user
- * is the only one who raises it back up via the knob.
+ * Movement sensitivity (non-sensitive) lives in plain prefs; per the "one-way
+ * conservative" rule, automatic adjustments only ever *lower* it. The ACRCloud
+ * credentials are sensitive, so they live in an encrypted prefs file.
  */
 object SettingsStore {
 
     private const val PREFS = "mmd_settings"
+    private const val SECURE_PREFS = "mmd_secure_settings"
     private const val KEY_SENSITIVITY = "sensitivity"
+    private const val KEY_ACR_HOST = "acr_host"
+    private const val KEY_ACR_KEY = "acr_key"
+    private const val KEY_ACR_SECRET = "acr_secret"
     private const val DEFAULT_SENSITIVITY = 0.5f
 
     // How far one rejected clip pulls sensitivity down.
     private const val REJECT_STEP = 0.08f
 
     private var prefs: SharedPreferences? = null
+    private var securePrefs: SharedPreferences? = null
 
     private val _sensitivity = MutableStateFlow(DEFAULT_SENSITIVITY)
     val sensitivity: StateFlow<Float> = _sensitivity.asStateFlow()
 
+    private val _acrHost = MutableStateFlow("")
+    val acrHost: StateFlow<String> = _acrHost.asStateFlow()
+
+    private val _acrKey = MutableStateFlow("")
+    val acrKey: StateFlow<String> = _acrKey.asStateFlow()
+
+    private val _acrSecret = MutableStateFlow("")
+    val acrSecret: StateFlow<String> = _acrSecret.asStateFlow()
+
+    private val _acrConfigured = MutableStateFlow(false)
+    val acrConfigured: StateFlow<Boolean> = _acrConfigured.asStateFlow()
+
     fun init(context: Context) {
         if (prefs != null) return
-        prefs = context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE).also {
+        val app = context.applicationContext
+        prefs = app.getSharedPreferences(PREFS, Context.MODE_PRIVATE).also {
             _sensitivity.value = it.getFloat(KEY_SENSITIVITY, DEFAULT_SENSITIVITY)
         }
+        securePrefs = openSecurePrefs(app)
+        securePrefs?.let {
+            _acrHost.value = it.getString(KEY_ACR_HOST, "") ?: ""
+            _acrKey.value = it.getString(KEY_ACR_KEY, "") ?: ""
+            _acrSecret.value = it.getString(KEY_ACR_SECRET, "") ?: ""
+        }
+        recomputeAcrConfigured()
+    }
+
+    private fun openSecurePrefs(app: Context): SharedPreferences? = try {
+        val masterKey = MasterKey.Builder(app)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            app,
+            SECURE_PREFS,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    } catch (_: Exception) {
+        // Keystore unavailable/corrupt — credentials simply won't persist.
+        null
     }
 
     fun setSensitivity(value: Float) {
@@ -49,5 +91,22 @@ object SettingsStore {
     /** A good catch: confirms the current setting. Never auto-raises sensitivity. */
     fun recordAccept() {
         // One-way conservative — intentionally a no-op on the threshold.
+    }
+
+    fun setAcrCredentials(host: String, key: String, secret: String) {
+        _acrHost.value = host.trim()
+        _acrKey.value = key.trim()
+        _acrSecret.value = secret.trim()
+        securePrefs?.edit()
+            ?.putString(KEY_ACR_HOST, _acrHost.value)
+            ?.putString(KEY_ACR_KEY, _acrKey.value)
+            ?.putString(KEY_ACR_SECRET, _acrSecret.value)
+            ?.apply()
+        recomputeAcrConfigured()
+    }
+
+    private fun recomputeAcrConfigured() {
+        _acrConfigured.value =
+            _acrHost.value.isNotBlank() && _acrKey.value.isNotBlank() && _acrSecret.value.isNotBlank()
     }
 }

--- a/app/src/main/java/com/hereliesaz/mademedance/ui/ClipListScreen.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/ui/ClipListScreen.kt
@@ -5,16 +5,19 @@ import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -30,6 +33,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,24 +42,35 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import com.hereliesaz.mademedance.ClipRecognition
 import com.hereliesaz.mademedance.data.ClipItem
 import com.hereliesaz.mademedance.data.ClipRepository
 import com.hereliesaz.mademedance.identify.IdentifyResult
 import com.hereliesaz.mademedance.identify.SongIdentifier
 import com.hereliesaz.mademedance.service.BeatMatcherState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+private const val LOOPBACK_DURATION_MS = 30_000L
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ClipListScreen(
     clipRepository: ClipRepository?,
+    acrConfigured: Boolean = false,
+    recognition: ClipRecognition = ClipRecognition.Idle,
     onAccept: (ClipItem) -> Unit = {},
     onReject: (ClipItem) -> Unit = {},
+    onRecognize: (ClipItem) -> Unit = {},
+    onClearRecognition: () -> Unit = {},
     onBackClick: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val clips = remember { mutableStateListOf<ClipItem>() }
     val lifecycleOwner = LocalLifecycleOwner.current
+    val scope = rememberCoroutineScope()
 
     // Refresh clip list whenever this screen becomes visible or the service signals a new clip
     LaunchedEffect(lifecycleOwner) {
@@ -71,6 +86,25 @@ fun ClipListScreen(
     var selectedClip by remember { mutableStateOf<ClipItem?>(null) }
     var nowPlaying by remember { mutableStateOf<IdentifyResult.NowPlaying?>(null) }
 
+    val mediaPlayer = remember { MediaPlayer() }
+    var loopbackJob by remember { mutableStateOf<Job?>(null) }
+
+    fun stopLoopback() {
+        loopbackJob?.cancel()
+        loopbackJob = null
+        try {
+            if (mediaPlayer.isPlaying) mediaPlayer.stop()
+            mediaPlayer.isLooping = false
+        } catch (_: Exception) { /* ignore */ }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            loopbackJob?.cancel()
+            mediaPlayer.release()
+        }
+    }
+
     nowPlaying?.let { np ->
         NowPlayingDialog(
             nowPlaying = np,
@@ -82,28 +116,47 @@ fun ClipListScreen(
         )
     }
 
-    val mediaPlayer = remember { MediaPlayer() }
-    DisposableEffect(Unit) {
-        onDispose {
-            mediaPlayer.release()
-        }
+    fun closeDialog() {
+        showDialog = false
+        onClearRecognition()
     }
 
     if (showDialog && selectedClip != null) {
         val clip = selectedClip!!
+        // Prefer a just-recognized result, else any song stored with the clip.
+        val done = recognition as? ClipRecognition.Done
+        val songTitle = done?.title ?: clip.title
+        val songArtist = done?.artist ?: clip.artist
+
         AlertDialog(
-            onDismissRequest = { showDialog = false },
+            onDismissRequest = { closeDialog() },
             title = { Text(clip.formattedDate) },
             text = {
                 Column {
+                    if (!songTitle.isNullOrBlank()) {
+                        Text(
+                            text = listOfNotNull(songArtist, songTitle).joinToString(" — "),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        TextButton(onClick = {
+                            SongIdentifier.searchForKnownSong(context, songArtist, songTitle)
+                        }) {
+                            Text("Search the web")
+                        }
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+
                     Text("Was this a real catch? Rating tunes how sensitive the detector is.")
                     Spacer(modifier = Modifier.height(8.dp))
+
                     TextButton(onClick = {
                         val file = clipRepository?.getClipFile(clip.name)
                         if (file != null) {
                             try {
+                                stopLoopback()
                                 mediaPlayer.reset()
                                 mediaPlayer.setDataSource(file.absolutePath)
+                                mediaPlayer.isLooping = false
                                 mediaPlayer.prepare()
                                 mediaPlayer.start()
                             } catch (e: Exception) {
@@ -113,17 +166,80 @@ fun ClipListScreen(
                     }) {
                         Text("Review (play clip)")
                     }
+
+                    if (acrConfigured) {
+                        when (recognition) {
+                            ClipRecognition.Loading -> Row(verticalAlignment = Alignment.CenterVertically) {
+                                CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                                Spacer(modifier = Modifier.size(8.dp))
+                                Text("Identifying this clip…")
+                            }
+                            ClipRecognition.NoMatch -> Text(
+                                "No match found for this clip.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            is ClipRecognition.Error -> Text(
+                                (recognition as ClipRecognition.Error).message,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                            else -> TextButton(onClick = { onRecognize(clip) }) {
+                                Text("Identify this clip")
+                            }
+                        }
+                    }
+
                     TextButton(onClick = {
-                        showDialog = false
+                        val file = clipRepository?.getClipFile(clip.name)
+                        if (file == null) {
+                            Toast.makeText(context, "Clip not found", Toast.LENGTH_SHORT).show()
+                            return@TextButton
+                        }
+                        try {
+                            mediaPlayer.reset()
+                            mediaPlayer.setDataSource(file.absolutePath)
+                            mediaPlayer.isLooping = true
+                            mediaPlayer.prepare()
+                            mediaPlayer.start()
+                        } catch (e: Exception) {
+                            Toast.makeText(context, "Failed to play clip", Toast.LENGTH_SHORT).show()
+                            return@TextButton
+                        }
+                        val label = SongIdentifier.launchAnyRecognizer(context)
+                        if (label == null) {
+                            stopLoopback()
+                            Toast.makeText(
+                                context,
+                                "No song finder installed — grab Shazam, SoundHound, or the Google app.",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        } else {
+                            Toast.makeText(
+                                context, "Looping your clip — tap Listen in $label", Toast.LENGTH_LONG
+                            ).show()
+                            loopbackJob?.cancel()
+                            loopbackJob = scope.launch {
+                                delay(LOOPBACK_DURATION_MS)
+                                stopLoopback()
+                            }
+                            closeDialog()
+                        }
+                    }) {
+                        Text("Play to a song finder")
+                    }
+
+                    TextButton(onClick = {
+                        closeDialog()
                         runIdentify(context) { nowPlaying = it }
                     }) {
-                        Text("Identify song")
+                        Text("What's playing now")
                     }
                 }
             },
             confirmButton = {
                 TextButton(onClick = {
-                    showDialog = false
+                    closeDialog()
                     onAccept(clip)
                 }) {
                     Text("Good catch")
@@ -131,7 +247,7 @@ fun ClipListScreen(
             },
             dismissButton = {
                 TextButton(onClick = {
-                    showDialog = false
+                    closeDialog()
                     onReject(clip)
                     clips.remove(clip)
                 }) {
@@ -182,17 +298,22 @@ fun ClipListScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
+                                onClearRecognition()
                                 selectedClip = clip
                                 showDialog = true
                             }
                             .padding(8.dp)
                     ) {
                         Text(
-                            text = clip.formattedDate,
+                            text = if (clip.knownSong) {
+                                listOfNotNull(clip.artist, clip.title).joinToString(" — ")
+                            } else {
+                                clip.formattedDate
+                            },
                             style = MaterialTheme.typography.bodyLarge
                         )
                         Text(
-                            text = "15s audio clip",
+                            text = if (clip.knownSong) clip.formattedDate else "15s audio clip",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )

--- a/app/src/main/java/com/hereliesaz/mademedance/ui/ClipListScreen.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/ui/ClipListScreen.kt
@@ -1,7 +1,5 @@
 package com.hereliesaz.mademedance.ui
 
-import android.app.SearchManager
-import android.content.Intent
 import android.media.MediaPlayer
 import android.widget.Toast
 import androidx.compose.foundation.clickable
@@ -42,6 +40,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.hereliesaz.mademedance.data.ClipItem
 import com.hereliesaz.mademedance.data.ClipRepository
+import com.hereliesaz.mademedance.identify.IdentifyResult
+import com.hereliesaz.mademedance.identify.SongIdentifier
 import com.hereliesaz.mademedance.service.BeatMatcherState
 import kotlinx.coroutines.flow.collectLatest
 
@@ -69,6 +69,18 @@ fun ClipListScreen(
 
     var showDialog by remember { mutableStateOf(false) }
     var selectedClip by remember { mutableStateOf<ClipItem?>(null) }
+    var nowPlaying by remember { mutableStateOf<IdentifyResult.NowPlaying?>(null) }
+
+    nowPlaying?.let { np ->
+        NowPlayingDialog(
+            nowPlaying = np,
+            onSearch = {
+                SongIdentifier.searchForKnownSong(context, np.artist, np.title)
+                nowPlaying = null
+            },
+            onDismiss = { nowPlaying = null }
+        )
+    }
 
     val mediaPlayer = remember { MediaPlayer() }
     DisposableEffect(Unit) {
@@ -102,11 +114,8 @@ fun ClipListScreen(
                         Text("Review (play clip)")
                     }
                     TextButton(onClick = {
-                        Toast.makeText(context, "Tap the microphone and hum the tune!", Toast.LENGTH_LONG).show()
-                        val intent = Intent(Intent.ACTION_WEB_SEARCH).apply {
-                            putExtra(SearchManager.QUERY, "what is this song")
-                        }
-                        context.startActivity(intent)
+                        showDialog = false
+                        runIdentify(context) { nowPlaying = it }
                     }) {
                         Text("Identify song")
                     }

--- a/app/src/main/java/com/hereliesaz/mademedance/ui/ClipListScreen.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/ui/ClipListScreen.kt
@@ -7,9 +7,10 @@ import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -48,6 +49,8 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun ClipListScreen(
     clipRepository: ClipRepository?,
+    onAccept: (ClipItem) -> Unit = {},
+    onReject: (ClipItem) -> Unit = {},
     onBackClick: () -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -79,31 +82,11 @@ fun ClipListScreen(
         AlertDialog(
             onDismissRequest = { showDialog = false },
             title = { Text(clip.formattedDate) },
-            text = { Text("What would you like to do with this clip?") },
-            confirmButton = {
-                TextButton(onClick = {
-                    showDialog = false
-                    Toast.makeText(context, "Tap the microphone and hum the tune!", Toast.LENGTH_LONG).show()
-                    val intent = Intent(Intent.ACTION_WEB_SEARCH).apply {
-                        putExtra(SearchManager.QUERY, "what is this song")
-                    }
-                    context.startActivity(intent)
-                }) {
-                    Text("Identify")
-                }
-            },
-            dismissButton = {
-                Row {
+            text = {
+                Column {
+                    Text("Was this a real catch? Rating tunes how sensitive the detector is.")
+                    Spacer(modifier = Modifier.height(8.dp))
                     TextButton(onClick = {
-                        showDialog = false
-                        if (clipRepository?.deleteClip(clip.name) == true) {
-                            clips.remove(clip)
-                        }
-                    }) {
-                        Text("Delete")
-                    }
-                    TextButton(onClick = {
-                        showDialog = false
                         val file = clipRepository?.getClipFile(clip.name)
                         if (file != null) {
                             try {
@@ -116,8 +99,34 @@ fun ClipListScreen(
                             }
                         }
                     }) {
-                        Text("Review")
+                        Text("Review (play clip)")
                     }
+                    TextButton(onClick = {
+                        Toast.makeText(context, "Tap the microphone and hum the tune!", Toast.LENGTH_LONG).show()
+                        val intent = Intent(Intent.ACTION_WEB_SEARCH).apply {
+                            putExtra(SearchManager.QUERY, "what is this song")
+                        }
+                        context.startActivity(intent)
+                    }) {
+                        Text("Identify song")
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDialog = false
+                    onAccept(clip)
+                }) {
+                    Text("Good catch")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showDialog = false
+                    onReject(clip)
+                    clips.remove(clip)
+                }) {
+                    Text("False alarm")
                 }
             }
         )

--- a/app/src/main/java/com/hereliesaz/mademedance/ui/IdentifyDialog.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/ui/IdentifyDialog.kt
@@ -1,0 +1,50 @@
+package com.hereliesaz.mademedance.ui
+
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import com.hereliesaz.mademedance.identify.IdentifyResult
+import com.hereliesaz.mademedance.identify.SongIdentifier
+
+/**
+ * Runs the identification chain. For the in-app "now playing" result it calls
+ * [onNowPlaying] so the caller can show a dialog; the other outcomes
+ * (launching an app, or nothing installed) are surfaced with a toast since the
+ * chain has already navigated away.
+ */
+fun runIdentify(context: Context, onNowPlaying: (IdentifyResult.NowPlaying) -> Unit) {
+    when (val result = SongIdentifier.identify(context)) {
+        is IdentifyResult.NowPlaying -> onNowPlaying(result)
+        is IdentifyResult.OpenedApp ->
+            Toast.makeText(context, "Opening ${result.label}…", Toast.LENGTH_SHORT).show()
+        IdentifyResult.NoRecognizer ->
+            Toast.makeText(
+                context,
+                "No song finder installed — grab Shazam, SoundHound, or the Google app.",
+                Toast.LENGTH_LONG
+            ).show()
+    }
+}
+
+@Composable
+fun NowPlayingDialog(
+    nowPlaying: IdentifyResult.NowPlaying,
+    onSearch: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val label = listOfNotNull(nowPlaying.artist, nowPlaying.title).joinToString(" — ")
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Playing now") },
+        text = { Text(label) },
+        confirmButton = {
+            TextButton(onClick = onSearch) { Text("Search the web") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        }
+    )
+}

--- a/app/src/main/java/com/hereliesaz/mademedance/ui/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/ui/MainScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -49,6 +50,10 @@ fun MainScreen(
     isServiceRunning: Boolean,
     movementBpm: Float?,
     audioBpm: Float?,
+    sensitivity: Float,
+    batteryDrainPerHour: Float?,
+    powerSaving: Boolean,
+    onSensitivityChange: (Float) -> Unit,
     onStartClick: () -> Unit,
     onStopClick: () -> Unit,
     onPermissionClick: () -> Unit,
@@ -98,6 +103,15 @@ fun MainScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
+            SensitivityControl(
+                sensitivity = sensitivity,
+                powerSaving = powerSaving,
+                batteryDrainPerHour = batteryDrainPerHour,
+                onSensitivityChange = onSensitivityChange
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
             when {
                 !hasAudioPermission -> {
                     Button(onClick = onPermissionClick) {
@@ -136,6 +150,54 @@ fun MainScreen(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun SensitivityControl(
+    sensitivity: Float,
+    powerSaving: Boolean,
+    batteryDrainPerHour: Float?,
+    onSensitivityChange: (Float) -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Sensitivity: ${"%.0f".format(sensitivity * 100)}%",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Slider(
+            value = sensitivity,
+            onValueChange = onSensitivityChange,
+            valueRange = 0f..1f,
+            modifier = Modifier.fillMaxWidth(0.8f)
+        )
+        Text(
+            text = "Lower for vigorous dancing, higher for subtle movement.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+        if (batteryDrainPerHour != null) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = if (powerSaving) {
+                    "Battery: ~${"%.0f".format(batteryDrainPerHour)}%/hr — power-saving, sensitivity reduced"
+                } else {
+                    "Battery: ~${"%.0f".format(batteryDrainPerHour)}%/hr"
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = if (powerSaving) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                textAlign = TextAlign.Center
+            )
         }
     }
 }

--- a/app/src/main/java/com/hereliesaz/mademedance/ui/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/ui/MainScreen.kt
@@ -59,7 +59,8 @@ fun MainScreen(
     onStartClick: () -> Unit,
     onStopClick: () -> Unit,
     onPermissionClick: () -> Unit,
-    onClipListClick: () -> Unit
+    onClipListClick: () -> Unit,
+    onSettingsClick: () -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -68,6 +69,9 @@ fun MainScreen(
                 actions = {
                     TextButton(onClick = onClipListClick) {
                         Text("Clips")
+                    }
+                    TextButton(onClick = onSettingsClick) {
+                        Text("Settings")
                     }
                 }
             )

--- a/app/src/main/java/com/hereliesaz/mademedance/ui/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/ui/MainScreen.kt
@@ -53,7 +53,9 @@ fun MainScreen(
     sensitivity: Float,
     batteryDrainPerHour: Float?,
     powerSaving: Boolean,
+    hasNowPlayingAccess: Boolean,
     onSensitivityChange: (Float) -> Unit,
+    onEnableNowPlaying: () -> Unit,
     onStartClick: () -> Unit,
     onStopClick: () -> Unit,
     onPermissionClick: () -> Unit,
@@ -109,6 +111,12 @@ fun MainScreen(
                 batteryDrainPerHour = batteryDrainPerHour,
                 onSensitivityChange = onSensitivityChange
             )
+
+            if (!hasNowPlayingAccess) {
+                TextButton(onClick = onEnableNowPlaying) {
+                    Text("Enable now-playing detection")
+                }
+            }
 
             Spacer(modifier = Modifier.height(24.dp))
 

--- a/app/src/main/java/com/hereliesaz/mademedance/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/ui/SettingsScreen.kt
@@ -1,0 +1,125 @@
+package com.hereliesaz.mademedance.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    acrHost: String,
+    acrKey: String,
+    acrSecret: String,
+    onSave: (host: String, key: String, secret: String) -> Unit,
+    onBack: () -> Unit
+) {
+    var host by remember(acrHost) { mutableStateOf(acrHost) }
+    var key by remember(acrKey) { mutableStateOf(acrKey) }
+    var secret by remember(acrSecret) { mutableStateOf(acrSecret) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = "Identify saved clips (ACRCloud)",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "Recognizer apps only hear live audio. To identify a clip after the " +
+                    "song has stopped, create a free ACRCloud project and paste its " +
+                    "credentials here. Stored encrypted on this device only.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = host,
+                onValueChange = { host = it },
+                label = { Text("Host (e.g. identify-eu-west-1.acrcloud.com)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = key,
+                onValueChange = { key = it },
+                label = { Text("Access key") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = secret,
+                onValueChange = { secret = it },
+                label = { Text("Access secret") },
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(20.dp))
+            Button(
+                onClick = {
+                    onSave(host, key, secret)
+                    onBack()
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Save")
+            }
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = {
+                    host = ""; key = ""; secret = ""
+                    onSave("", "", "")
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Clear")
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ activity-compose = "1.9.3"
 commons-math3 = "3.6.1"
 navigation-compose = "2.8.5"
 lifecycle = "2.8.7"
+security-crypto = "1.1.0-alpha06"
 
 
 [libraries]
@@ -33,6 +34,7 @@ androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecyc
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-compose-material-icons = { group = "androidx.compose.material", name = "material-icons-core" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "security-crypto" }
 
 
 [plugins]


### PR DESCRIPTION
Two related changes — the sensitivity work is built directly on the accelerometer fix, so they ship together.

## 1. Accelerometer instead of gyroscope

The movement detector read `TYPE_GYROSCOPE`, which only senses rotation. A phone in your pocket barely rotates while you dance — it gets bounced/jolted (linear acceleration). Fixed:

- `MovementTracker` now listens to `TYPE_ACCELEROMETER`.
- `RhythmDetector` subtracts the windowed mean (drops gravity's DC offset) before the FFT, and adds parabolic peak interpolation so the BPM estimate is finer than the ~23 BPM-wide FFT bins (otherwise it could never land in the 5 BPM match window).
- Manifest `uses-feature`, status copy, README updated.

## 2. Sensitivity tuner

A user-tunable movement sensitivity, plus two automatic signals that can **only ever lower** it (you raise it back with the knob — "one-way conservative"):

- **Manual knob** — a slider on the main screen, mapped to the detection threshold via `RhythmDetector.thresholdForSensitivity()`, persisted in `SettingsStore` (SharedPreferences).
- **Ratings** — the clip dialog now asks **"Good catch"** vs **"False alarm."** A false alarm deletes the clip and nudges sensitivity down; a good catch keeps it and changes nothing.
- **Battery awareness** — the service samples battery level over a 10-minute window; when drain is high it enters **power-saving**: reduces sensitivity *and* stretches the audio-processing interval. The cadence stretch is the real power lever, since the always-on mic + FFT loop dominates draw — lowering match sensitivity alone barely saves anything.

Plumbing: `SettingsStore` singleton initialized from a new `MadeMeDanceApp` Application class; effective threshold + audio cadence pushed live into the running detector from `BeatMatcherService`; battery drain / power-saving surfaced in `BeatMatcherState`, the ongoing notification, and the main screen.

## Caveats / worth a look

- **Unverified on hardware** — no Android SDK in my environment, so none of this is build- or run-tested.
- Several constants are **empirical first guesses needing on-device tuning**: the sensitivity→threshold endpoints (`120.0`/`15.0` m/s² in `RhythmDetector`), the battery drain band (`DRAIN_OK_PER_HOUR=8`, `DRAIN_HIGH_PER_HOUR=25`), `MAX_BATTERY_SENSITIVITY_PENALTY=0.4`, and the audio interval range (100–400 ms).
- "Battery consumption" is approximated by overall device drain while the service runs — Android doesn't expose cheap real-time per-app power.

## Test plan

- [ ] `./gradlew assembleDebug` and `./gradlew testDebugUnitTest`.
- [ ] Phone in pocket, dance — confirm movement BPM appears; adjust the knob and confirm it gets more/less twitchy.
- [ ] Rate a clip "False alarm" — confirm the knob drops and the clip is deleted.
- [ ] Let it run and watch the notification's `%/hr`; under heavy drain confirm it flips to "power-saving."
- [ ] Confirm walking doesn't constantly trigger matches at the default sensitivity; tune constants if needed.

## Summary by Sourcery

Switch movement detection to the accelerometer and introduce user- and system-driven sensitivity control, along with richer song identification paths and clip metadata handling.

New Features:
- Add a sensitivity slider with persisted settings that tunes movement detection thresholds and can be lowered automatically based on user ratings and battery conditions.
- Introduce battery-aware power-saving that adapts microphone cadence and detector sensitivity based on estimated drain, and reflects this state in the UI and notifications.
- Support multiple song identification flows, including reading now-playing media, recognizing saved clips via user-provided ACRCloud credentials, and integrating with external recognizer apps and web search.
- Store identified song metadata alongside saved clips and surface known titles/artists throughout the UI, including in match and clip list screens.
- Add an in-app Settings screen for configuring ACRCloud credentials, stored securely with encrypted preferences.

Enhancements:
- Replace gyroscope-based movement tracking with accelerometer-based detection, including improved FFT processing and peak interpolation for finer BPM resolution.
- Ensure microphone recording sessions are started and stopped dynamically based on detected dancing, with state reset between sessions to avoid stale audio influencing detection.
- Extend foreground and match notifications with clearer status text, battery drain estimates, and context-aware messaging when the current song is already known.

Build:
- Add androidx security crypto dependency for encrypted storage of sensitive settings.

Documentation:
- Update README to describe accelerometer-based movement detection, the new sensitivity tuning behavior, and the expanded song identification options.

Chores:
- Add an Application subclass to centralize settings initialization and register a no-op notification listener service needed for now-playing access permissions.