### PR TITLE
Address review feedback: sensor-loop allocations + listener match

### DIFF
--- a/app/src/main/java/com/hereliesaz/mademedance/RhythmDetector.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/RhythmDetector.kt
@@ -5,7 +5,6 @@ import org.apache.commons.math3.complex.Complex
 import org.apache.commons.math3.transform.DftNormalization
 import org.apache.commons.math3.transform.FastFourierTransformer
 import org.apache.commons.math3.transform.TransformType
-import java.util.*
 import kotlin.math.sqrt
 
 class RhythmDetector {
@@ -24,7 +23,18 @@ class RhythmDetector {
     }
 
     private val windowSize = 128
-    private val dataQueue = ArrayDeque<Pair<Long, Double>>(windowSize)
+
+    // Circular buffers of primitives — sensor events arrive at SENSOR_DELAY_GAME,
+    // so a per-event Pair allocation would churn the GC. head = oldest sample.
+    private val timestamps = LongArray(windowSize)
+    private val magnitudes = DoubleArray(windowSize)
+    private var head = 0
+    private var size = 0
+
+    // Reused FFT input (chronological, gravity-removed); avoids re-allocating
+    // an array every event. The transformer is stateless and reusable.
+    private val fftInput = DoubleArray(windowSize)
+    private val transformer = FastFourierTransformer(DftNormalization.STANDARD)
 
     // Threshold on the dominant FFT bin of the gravity-removed accelerometer
     // magnitude (m/s²). Driven by the user's sensitivity setting; updated live
@@ -33,20 +43,23 @@ class RhythmDetector {
     var energyThreshold: Double = thresholdForSensitivity(0.5f)
 
     fun getMovementBpm(event: SensorEvent): Float? {
-        val timestamp = event.timestamp
         val v = event.values
         val magnitude = sqrt((v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).toDouble())
 
-        dataQueue.addLast(Pair(timestamp, magnitude))
-        if (dataQueue.size > windowSize) {
-            dataQueue.removeFirst()
+        val index = if (size < windowSize) {
+            ((head + size) % windowSize).also { size++ }
+        } else {
+            head.also { head = (head + 1) % windowSize }
         }
-        if (dataQueue.size < windowSize) {
+        timestamps[index] = event.timestamp
+        magnitudes[index] = magnitude
+
+        if (size < windowSize) {
             return null // Not enough data yet
         }
 
-        val firstTimestamp = dataQueue.first.first
-        val lastTimestamp = dataQueue.last.first
+        val firstTimestamp = timestamps[head]
+        val lastTimestamp = timestamps[(head + windowSize - 1) % windowSize]
         val durationNanos = lastTimestamp - firstTimestamp
         if (durationNanos <= 0L) return null
 
@@ -55,10 +68,14 @@ class RhythmDetector {
 
         // Subtract the mean so gravity (a large DC offset on the accelerometer)
         // doesn't dominate; what's left is the oscillation from body movement.
-        val mean = dataQueue.sumOf { it.second } / windowSize
-        val transformer = FastFourierTransformer(DftNormalization.STANDARD)
-        val complexData = dataQueue.map { Complex(it.second - mean) }.toTypedArray()
-        val fftResults = transformer.transform(complexData, TransformType.FORWARD)
+        var sum = 0.0
+        for (m in magnitudes) sum += m
+        val mean = sum / windowSize
+
+        for (i in 0 until windowSize) {
+            fftInput[i] = magnitudes[(head + i) % windowSize] - mean
+        }
+        val fftResults = transformer.transform(fftInput, TransformType.FORWARD)
 
         var maxMagnitude = -1.0
         var dominantBin = 0

--- a/app/src/main/java/com/hereliesaz/mademedance/RhythmDetector.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/RhythmDetector.kt
@@ -72,8 +72,11 @@ class RhythmDetector {
         for (m in magnitudes) sum += m
         val mean = sum / windowSize
 
+        val firstPart = windowSize - head
+        System.arraycopy(magnitudes, head, fftInput, 0, firstPart)
+        System.arraycopy(magnitudes, 0, fftInput, firstPart, head)
         for (i in 0 until windowSize) {
-            fftInput[i] = magnitudes[(head + i) % windowSize] - mean
+            fftInput[i] -= mean
         }
         val fftResults = transformer.transform(fftInput, TransformType.FORWARD)
 

--- a/app/src/main/java/com/hereliesaz/mademedance/identify/SongIdentifier.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/identify/SongIdentifier.kt
@@ -51,8 +51,12 @@ object SongIdentifier {
         val enabled = Settings.Secure.getString(
             context.contentResolver, "enabled_notification_listeners"
         ) ?: return false
-        val me = context.packageName
-        return enabled.split(":").any { it.contains(me) }
+        val mine = ComponentName(context, NowPlayingListenerService::class.java)
+        // Exact component match — a substring check would false-positive on any
+        // app whose package merely contains ours.
+        return enabled.split(":").any { entry ->
+            ComponentName.unflattenFromString(entry) == mine
+        }
     }
 
     fun openNotificationAccessSettings(context: Context) {


### PR DESCRIPTION
Follow-up fixes from review comments on #8.

## 1. `RhythmDetector` allocation churn (high)
`getMovementBpm` runs on every accelerometer event (SENSOR_DELAY_GAME ≈ 50 Hz). The old code allocated a `Pair<Long, Double>` per event and rebuilt a `Complex[]` via `map { … }.toTypedArray()` each frame — steady GC pressure.

- Replaced the `ArrayDeque<Pair<Long, Double>>` with two primitive circular buffers (`LongArray` timestamps + `DoubleArray` magnitudes), no per-event allocation/boxing.
- Feed the FFT a single reused `DoubleArray` via Apache Commons Math's `transform(double[], …)` overload — drops the intermediate `List` and the input `Complex[]`.
- Hoisted the `FastFourierTransformer` to a reused field (it's stateless).

(`getMovementBpm` is only called from the single sensor-callback thread, so the reused buffers need no synchronization.)

## 2. Notification-listener match could false-positive (bug risk)
`hasNotificationAccess` used `enabled.split(":").any { it.contains(packageName) }`, which would match any app whose package merely contains ours as a substring. Now compares each entry by exact `ComponentName` (`unflattenFromString(entry) == mine`), which also handles the relative `pkg/.Class` form.

## Test plan
- [ ] `./gradlew assembleDebug` / `testDebugUnitTest`.
- [ ] Verify movement BPM still tracks while dancing (ring-buffer ordering correct).
- [ ] Verify "Enable now-playing detection" reflects the real grant state and now-playing reads still work after granting.

Still unverified on hardware (no Android SDK in my environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSwbN23GDY58SDdpK7sjEg)_

## Summary by Sourcery

Optimize sensor-based rhythm detection and tighten notification listener access checks.

Bug Fixes:
- Prevent false-positive notification access detection by requiring an exact ComponentName match for the enabled listener.

Enhancements:
- Reduce GC pressure in RhythmDetector by replacing per-event allocations with primitive circular buffers and a reused FFT input array.