### PR TITLE
Detect walking and suppress false beat matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Once a clip's song is known, it shows the title/artist in the list with a one-ta
 
 It runs as a background **foreground service**, so you can pocket the phone and keep dancing — no need to keep the app open. The cheap accelerometer runs continuously, but the **microphone only switches on once dancing is detected** and switches off again a few seconds after you stop — saving battery and keeping the mic off while you're still.
 
+### Ignoring walking
+
+A walk has a steady footfall cadence that lands in the same BPM range as music, so on its own it would trigger constant false matches. The app watches the device's **step-detector sensor**: when it sees a sustained, regular walking/running cadence, it treats the motion as walking and **suppresses matches** (and leaves the mic off) until you stop. Dance footwork is comparatively irregular, so it's left alone. This needs a one-time *physical activity* permission; if it's declined or the device has no step detector, the app simply behaves as before.
+
 ### Tuning sensitivity
 
 - A **sensitivity knob** on the main screen sets how much movement counts as dancing (lower for vigorous dancing, higher for subtle motion).
@@ -40,7 +44,8 @@ mademedance/
 ├── data/
 │   └── ClipRepository.kt       # File-based clip management (list, delete)
 ├── sensor/
-│   └── MovementTracker.kt      # Accelerometer sensor wrapper, exposes BPM StateFlow
+│   ├── MovementTracker.kt      # Accelerometer sensor wrapper, exposes BPM StateFlow
+│   └── WalkingDetector.kt      # Step-sensor gait detector; flags walking to suppress matches
 └── ui/
     ├── MainScreen.kt            # Pulse ring animation, match proximity bar
     ├── ClipListScreen.kt        # Clip list with playback, deletion, identification
@@ -69,6 +74,7 @@ Requires Android Studio and the Android SDK.
 ## Permissions
 
 - `RECORD_AUDIO` — microphone access for music BPM detection
+- `ACTIVITY_RECOGNITION` — step-detector access to recognise and ignore walking (optional; granted at runtime on Android 10+)
 
 ## License
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,9 +9,14 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- Step-detector sensor, used to recognise (and ignore) walking. -->
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
 
     <uses-feature
         android:name="android.hardware.sensor.accelerometer"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.sensor.stepdetector"
         android:required="false" />
 
     <!-- Package visibility (API 30+) so we can detect/launch song recognizers. -->

--- a/app/src/main/java/com/hereliesaz/mademedance/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainActivity.kt
@@ -38,6 +38,10 @@ class MainActivity : ComponentActivity() {
     private lateinit var viewModel: MainViewModel
     private var pendingStartAfterPermissions = false
 
+    // Walking detection (step sensor) is optional, so we ask for its permission at
+    // most once per launch and start the service regardless of the answer.
+    private var activityRecognitionAsked = false
+
     // Bumped each time an "Identify" intent arrives (cold start or onNewIntent),
     // so the Compose tree can run the identification chain exactly once per tap.
     private val identifyTrigger = MutableStateFlow(0)
@@ -51,6 +55,16 @@ class MainActivity : ComponentActivity() {
         }
 
     private val requestNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { _ ->
+            viewModel.refreshPermissionState()
+            if (pendingStartAfterPermissions && viewModel.hasAudioPermission.value) {
+                maybeRequestActivityRecognitionThenStart()
+            } else {
+                pendingStartAfterPermissions = false
+            }
+        }
+
+    private val requestActivityRecognitionPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { _ ->
             viewModel.refreshPermissionState()
             if (pendingStartAfterPermissions && viewModel.hasAudioPermission.value) {
@@ -197,14 +211,34 @@ class MainActivity : ComponentActivity() {
             requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             return
         }
-        viewModel.startService()
+        pendingStartAfterPermissions = true
+        maybeRequestActivityRecognitionThenStart()
     }
 
     private fun maybeRequestNotificationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             !viewModel.hasNotificationPermission.value) {
             requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-        } else if (pendingStartAfterPermissions) {
+        } else {
+            maybeRequestActivityRecognitionThenStart()
+        }
+    }
+
+    /**
+     * Walking detection needs ACTIVITY_RECOGNITION (API 29+). It's optional — if
+     * denied or unavailable, the service still starts and simply won't suppress
+     * walking. Asked at most once per launch so a decline isn't nagged.
+     */
+    private fun maybeRequestActivityRecognitionThenStart() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+            !viewModel.hasActivityRecognitionPermission.value &&
+            !activityRecognitionAsked) {
+            activityRecognitionAsked = true
+            requestActivityRecognitionPermissionLauncher
+                .launch(Manifest.permission.ACTIVITY_RECOGNITION)
+            return
+        }
+        if (pendingStartAfterPermissions) {
             viewModel.startService()
             pendingStartAfterPermissions = false
         }

--- a/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/MainViewModel.kt
@@ -56,6 +56,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _hasNotificationPermission = MutableStateFlow(false)
     val hasNotificationPermission: StateFlow<Boolean> = _hasNotificationPermission.asStateFlow()
 
+    private val _hasActivityRecognitionPermission = MutableStateFlow(false)
+    val hasActivityRecognitionPermission: StateFlow<Boolean> =
+        _hasActivityRecognitionPermission.asStateFlow()
+
     private val _hasNowPlayingAccess = MutableStateFlow(false)
     val hasNowPlayingAccess: StateFlow<Boolean> = _hasNowPlayingAccess.asStateFlow()
 
@@ -75,6 +79,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
                 ContextCompat.checkSelfPermission(
                     ctx, Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED
+            } else true
+        _hasActivityRecognitionPermission.value =
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                ContextCompat.checkSelfPermission(
+                    ctx, Manifest.permission.ACTIVITY_RECOGNITION
                 ) == PackageManager.PERMISSION_GRANTED
             } else true
         _hasNowPlayingAccess.value = SongIdentifier.hasNotificationAccess(ctx)

--- a/app/src/main/java/com/hereliesaz/mademedance/sensor/WalkingDetector.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/sensor/WalkingDetector.kt
@@ -106,7 +106,7 @@ class WalkingDetector(private val sensorManager: SensorManager) : SensorEventLis
 
     override fun onSensorChanged(event: SensorEvent?) {
         if (event?.sensor?.type != Sensor.TYPE_STEP_DETECTOR) return
-        val now = System.currentTimeMillis()
+        val now = System.nanoTime() / 1_000_000L
         synchronized(lock) {
             stepTimes.addLast(now)
             prune(now)

--- a/app/src/main/java/com/hereliesaz/mademedance/sensor/WalkingDetector.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/sensor/WalkingDetector.kt
@@ -1,0 +1,123 @@
+package com.hereliesaz.mademedance.sensor
+
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.ArrayDeque
+import kotlin.math.sqrt
+
+/**
+ * Flags sustained, regular walking/running gait so the beat matcher can ignore
+ * it. A walk's footfall cadence lands in the same 60–180 BPM range as music, so
+ * without this it reads as "dancing" and triggers constant false matches.
+ *
+ * Uses the platform step-detector sensor (one event per detected step). A run of
+ * recent steps whose inter-step interval is steady (low coefficient of variation)
+ * and within an ambulation cadence is treated as walking. Dance footwork is
+ * comparatively irregular, so it's left alone.
+ *
+ * Degrades to a no-op — never reporting walking — when the device has no step
+ * detector or the ACTIVITY_RECOGNITION permission wasn't granted, preserving the
+ * prior behaviour rather than over-suppressing.
+ */
+class WalkingDetector(private val sensorManager: SensorManager) : SensorEventListener {
+
+    companion object {
+        // Only steps within this look-back window count; older ones are pruned so
+        // the flag clears soon after walking stops.
+        const val WINDOW_MS = 5_000L
+
+        // A sustained run of steps is required before committing — a couple of
+        // stray steps (or a few dance stomps) shouldn't suppress matching.
+        const val MIN_STEPS = 6
+
+        // Ambulation cadence band as the interval between steps. ~67–230 steps/min
+        // spans a slow stroll through a jog.
+        const val MIN_STEP_INTERVAL_MS = 260.0
+        const val MAX_STEP_INTERVAL_MS = 900.0
+
+        // Gait is highly periodic; dance footwork is not. CV = stddev / mean of the
+        // inter-step intervals.
+        const val MAX_INTERVAL_CV = 0.30
+
+        /**
+         * Pure classifier over recent step times (ms, ascending). Extracted for
+         * testability; the live detector feeds it the pruned window.
+         */
+        fun isWalkingCadence(stepTimesMs: List<Long>): Boolean {
+            if (stepTimesMs.size < MIN_STEPS) return false
+            val intervals = DoubleArray(stepTimesMs.size - 1)
+            var sum = 0.0
+            for (i in 1 until stepTimesMs.size) {
+                val d = (stepTimesMs[i] - stepTimesMs[i - 1]).toDouble()
+                intervals[i - 1] = d
+                sum += d
+            }
+            val mean = sum / intervals.size
+            if (mean < MIN_STEP_INTERVAL_MS || mean > MAX_STEP_INTERVAL_MS) return false
+            var varSum = 0.0
+            for (d in intervals) {
+                val diff = d - mean
+                varSum += diff * diff
+            }
+            val cv = sqrt(varSum / intervals.size) / mean
+            return cv <= MAX_INTERVAL_CV
+        }
+    }
+
+    private val stepSensor: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_STEP_DETECTOR)
+    val isAvailable: Boolean = stepSensor != null
+
+    // Guarded by `lock`: appended on the sensor thread, read from the service's
+    // coroutine dispatcher.
+    private val lock = Any()
+    private val stepTimes = ArrayDeque<Long>()
+
+    private val _walking = MutableStateFlow(false)
+    val walking: StateFlow<Boolean> = _walking.asStateFlow()
+
+    fun start() {
+        stepSensor?.let {
+            sensorManager.registerListener(this, it, SensorManager.SENSOR_DELAY_NORMAL)
+        }
+    }
+
+    fun stop() {
+        sensorManager.unregisterListener(this)
+        synchronized(lock) { stepTimes.clear() }
+        _walking.value = false
+    }
+
+    /**
+     * Prunes the look-back window to [now] and recomputes, updating [walking].
+     * Call at decision time so the flag both engages and clears promptly.
+     */
+    fun isWalking(now: Long = System.currentTimeMillis()): Boolean {
+        val recent = synchronized(lock) {
+            prune(now)
+            stepTimes.toList()
+        }
+        return isWalkingCadence(recent).also { _walking.value = it }
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event?.sensor?.type != Sensor.TYPE_STEP_DETECTOR) return
+        val now = System.currentTimeMillis()
+        synchronized(lock) {
+            stepTimes.addLast(now)
+            prune(now)
+        }
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) { /* Not used */ }
+
+    private fun prune(now: Long) {
+        while (stepTimes.isNotEmpty() && now - stepTimes.first > WINDOW_MS) {
+            stepTimes.removeFirst()
+        }
+    }
+}

--- a/app/src/main/java/com/hereliesaz/mademedance/sensor/WalkingDetector.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/sensor/WalkingDetector.kt
@@ -96,7 +96,7 @@ class WalkingDetector(private val sensorManager: SensorManager) : SensorEventLis
      * Prunes the look-back window to [now] and recomputes, updating [walking].
      * Call at decision time so the flag both engages and clears promptly.
      */
-    fun isWalking(now: Long = System.currentTimeMillis()): Boolean {
+    fun isWalking(now: Long = System.nanoTime() / 1_000_000L): Boolean {
         val recent = synchronized(lock) {
             prune(now)
             stepTimes.toList()

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
@@ -301,7 +301,7 @@ class BeatMatcherService : Service() {
 
     private fun checkForMatch() {
         // The audio loop also calls this; bail if the movement is just walking.
-        if (walkingDetector.isWalking()) return
+        if (walkingDetector.walking.value) return
         val movement = BeatMatcherState.movementBpm.value
         val audio = BeatMatcherState.audioBpm.value
         if (movement != null && audio != null && abs(movement - audio) < BPM_MATCH_THRESHOLD) {

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherService.kt
@@ -28,6 +28,7 @@ import com.hereliesaz.mademedance.data.writeClipMeta
 import com.hereliesaz.mademedance.identify.IdentifyResult
 import com.hereliesaz.mademedance.identify.SongIdentifier
 import com.hereliesaz.mademedance.sensor.MovementTracker
+import com.hereliesaz.mademedance.sensor.WalkingDetector
 import com.hereliesaz.mademedance.settings.SettingsStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -97,6 +98,7 @@ class BeatMatcherService : Service() {
 
     private lateinit var audioBpmDetector: AudioBpmDetector
     private lateinit var movementTracker: MovementTracker
+    private lateinit var walkingDetector: WalkingDetector
     private var wakeLock: PowerManager.WakeLock? = null
     private var matchCounter = 0
 
@@ -128,6 +130,7 @@ class BeatMatcherService : Service() {
         createNotificationChannels()
         val sensorManager = getSystemService(Context.SENSOR_SERVICE) as SensorManager
         movementTracker = MovementTracker(sensorManager)
+        walkingDetector = WalkingDetector(sensorManager)
         audioBpmDetector = AudioBpmDetector()
     }
 
@@ -166,14 +169,23 @@ class BeatMatcherService : Service() {
 
         if (movementTracker.isAvailable) {
             movementTracker.start()
+            walkingDetector.start()
             BeatMatcherState.setSystemStatus("Waiting for you to dance…")
             sensorJob = scope.launch {
                 movementTracker.bpm.collect { bpm ->
                     if (bpm != null) {
                         BeatMatcherState.setMovementBpm(bpm)
-                        lastDanceMs = System.currentTimeMillis()
-                        ensureAudioRunning()
-                        checkForMatch()
+                        // Walking's footfall cadence reads as a movement BPM; skip
+                        // the match path (and leave the mic off) while it's detected.
+                        val walking = walkingDetector.isWalking()
+                        BeatMatcherState.setWalking(walking)
+                        if (walking) {
+                            BeatMatcherState.setSystemStatus("Walking detected — ignoring movement.")
+                        } else {
+                            lastDanceMs = System.currentTimeMillis()
+                            ensureAudioRunning()
+                            checkForMatch()
+                        }
                     }
                 }
             }
@@ -196,6 +208,9 @@ class BeatMatcherService : Service() {
         notificationJob = scope.launch {
             while (isActive) {
                 delay(NOTIFICATION_UPDATE_INTERVAL_MS)
+                // Refresh so the flag clears within ~1s of the walk stopping, even
+                // when no movement events arrive to drive the collector above.
+                BeatMatcherState.setWalking(walkingDetector.isWalking())
                 updateForegroundNotification()
             }
         }
@@ -285,6 +300,8 @@ class BeatMatcherService : Service() {
     }
 
     private fun checkForMatch() {
+        // The audio loop also calls this; bail if the movement is just walking.
+        if (walkingDetector.isWalking()) return
         val movement = BeatMatcherState.movementBpm.value
         val audio = BeatMatcherState.audioBpm.value
         if (movement != null && audio != null && abs(movement - audio) < BPM_MATCH_THRESHOLD) {
@@ -337,6 +354,7 @@ class BeatMatcherService : Service() {
         sensitivityJob?.cancel(); sensitivityJob = null
         stopAudio()
         try { movementTracker.stop() } catch (_: Exception) {}
+        try { walkingDetector.stop() } catch (_: Exception) {}
         releaseWakeLock()
         batterySamples.clear()
         batteryPenalty = 0f
@@ -344,6 +362,7 @@ class BeatMatcherService : Service() {
         BeatMatcherState.setMovementBpm(null)
         BeatMatcherState.setBatteryDrainPerHour(null)
         BeatMatcherState.setPowerSaving(false)
+        BeatMatcherState.setWalking(false)
         BeatMatcherState.setSystemStatus("Service stopped.")
     }
 
@@ -430,10 +449,10 @@ class BeatMatcherService : Service() {
         val audio = BeatMatcherState.audioBpm.value
         val drain = BeatMatcherState.batteryDrainPerHour.value
         val powerSaving = BeatMatcherState.powerSaving.value
-        val base = if (BeatMatcherState.micActive.value) {
-            "Listening for the song"
-        } else {
-            "Watching for dancing"
+        val base = when {
+            BeatMatcherState.walking.value -> "Walking — ignoring"
+            BeatMatcherState.micActive.value -> "Listening for the song"
+            else -> "Watching for dancing"
         }
         val title = if (powerSaving) "$base (power-saving)" else base
         val body = buildString {

--- a/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherState.kt
+++ b/app/src/main/java/com/hereliesaz/mademedance/service/BeatMatcherState.kt
@@ -36,9 +36,13 @@ object BeatMatcherState {
     private val _micActive = MutableStateFlow(false)
     val micActive: StateFlow<Boolean> = _micActive.asStateFlow()
 
+    private val _walking = MutableStateFlow(false)
+    val walking: StateFlow<Boolean> = _walking.asStateFlow()
+
     internal fun setBatteryDrainPerHour(drain: Float?) { _batteryDrainPerHour.value = drain }
     internal fun setPowerSaving(saving: Boolean) { _powerSaving.value = saving }
     internal fun setMicActive(active: Boolean) { _micActive.value = active }
+    internal fun setWalking(walking: Boolean) { _walking.value = walking }
 
     internal fun setRunning(running: Boolean) { _isRunning.value = running }
     internal fun setMovementBpm(bpm: Float?) {

--- a/app/src/test/java/com/hereliesaz/mademedance/WalkingDetectorTest.kt
+++ b/app/src/test/java/com/hereliesaz/mademedance/WalkingDetectorTest.kt
@@ -1,0 +1,53 @@
+package com.hereliesaz.mademedance
+
+import com.hereliesaz.mademedance.sensor.WalkingDetector
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WalkingDetectorTest {
+
+    /** Build ascending step times from a base plus inter-step intervals (ms). */
+    private fun stepsFrom(vararg intervals: Long): List<Long> {
+        val times = ArrayList<Long>(intervals.size + 1)
+        var t = 1_000L
+        times.add(t)
+        for (i in intervals) {
+            t += i
+            times.add(t)
+        }
+        return times
+    }
+
+    @Test
+    fun `steady walking cadence is walking`() {
+        // ~120 steps/min (500 ms apart), seven steps, near-perfect regularity.
+        val steps = stepsFrom(500, 500, 510, 490, 500, 505)
+        assertTrue(WalkingDetector.isWalkingCadence(steps))
+    }
+
+    @Test
+    fun `too few steps is not walking`() {
+        val steps = stepsFrom(500, 500, 500) // 4 steps < MIN_STEPS
+        assertFalse(WalkingDetector.isWalkingCadence(steps))
+    }
+
+    @Test
+    fun `irregular dance footwork is not walking`() {
+        // Same step count, but wildly varying intervals — high CV.
+        val steps = stepsFrom(300, 900, 250, 800, 400, 1000)
+        assertFalse(WalkingDetector.isWalkingCadence(steps))
+    }
+
+    @Test
+    fun `cadence too slow is not walking`() {
+        // ~1.2 s between steps — slower than the ambulation band.
+        val steps = stepsFrom(1200, 1200, 1200, 1200, 1200, 1200)
+        assertFalse(WalkingDetector.isWalkingCadence(steps))
+    }
+
+    @Test
+    fun `empty input is not walking`() {
+        assertFalse(WalkingDetector.isWalkingCadence(emptyList()))
+    }
+}


### PR DESCRIPTION
## Problem

The app fires constantly while walking. A walk's footfall cadence (~90–140 steps/min) lands in the same 60–180 BPM range the accelerometer FFT treats as "dancing," so it matches the song's BPM and saves a clip. Crucially, *dancing to a song also produces a steady BPM*, so tempo alone can't separate the two — the distinguishing physical feature is **regular, repetitive gait**.

## Approach

A new `WalkingDetector` backed by the platform **step-detector sensor**. It keeps a short rolling window of recent step times and flags walking when there's a sustained run of steps (≥6 in 5s) whose inter-step intervals are both within an ambulation cadence (~67–230 steps/min) and highly regular (coefficient of variation ≤ 0.30). Dance footwork is comparatively irregular, so it's left alone.

When walking is detected, `BeatMatcherService`:
- skips the match path (guarded in both the sensor collector and `checkForMatch`, since the audio loop also calls it),
- leaves the mic off (doesn't refresh the dance timestamp, so the existing idle watchdog shuts it down),
- surfaces it in the foreground notification ("Walking — ignoring").

It **degrades to a no-op** — never reporting walking — when the device has no step detector or the `ACTIVITY_RECOGNITION` permission wasn't granted, preserving prior behaviour rather than over-suppressing.

## Changes

- `sensor/WalkingDetector.kt` — new step-sensor gait detector with a pure, unit-tested `isWalkingCadence` classifier.
- `service/BeatMatcherService.kt` — start/stop the detector, gate matching, reflect status in the notification.
- `service/BeatMatcherState.kt` — new `walking` StateFlow.
- `MainActivity.kt` / `MainViewModel.kt` — request `ACTIVITY_RECOGNITION` once during the start flow (non-blocking; service still starts if declined).
- `AndroidManifest.xml` — declare `ACTIVITY_RECOGNITION` permission and the optional step-detector feature.
- `README.md` — document the new behaviour and permission.

## Test plan

- [x] Unit tests for the cadence classifier (steady walk → walking; too few/irregular/too-slow → not walking). Logic also cross-checked in plain Java since the container has no Android SDK.
- [ ] On-device: confirm the app stops firing during a sustained walk and the notification shows "Walking — ignoring".
- [ ] On-device: confirm dancing in place still triggers matches as before.
- [ ] On-device: confirm graceful behaviour when `ACTIVITY_RECOGNITION` is denied (works as it did before this change).

> Note: a full Gradle build/`testDebugUnitTest` couldn't run in the session container (no Android SDK; network policy blocks the JDK/dependency downloads), so the unit tests should be run in CI / locally.

https://claude.ai/code/session_01XRvShDA4EUwAiE5VnBp3aC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRvShDA4EUwAiE5VnBp3aC)_

## Summary by Sourcery

Introduce walking detection using the step-detector sensor to suppress false beat matches from regular walking gait while preserving existing behavior when unavailable or denied.

New Features:
- Add a WalkingDetector sensor wrapper that classifies sustained, regular step cadence as walking to prevent beat matching during gait.
- Expose walking state in BeatMatcherState and surface walking status in the foreground notification title.

Enhancements:
- Gate beat matching and microphone activation in BeatMatcherService based on detected walking state, ensuring walking motion no longer triggers matches.
- Extend MainActivity/MainViewModel to request ACTIVITY_RECOGNITION permission once per launch while keeping the service functional if it is denied.

Build:
- Declare ACTIVITY_RECOGNITION permission and optional step-detector hardware feature in the Android manifest.

Documentation:
- Update README to describe walking suppression behavior, the new step-detector-based detection, and the optional ACTIVITY_RECOGNITION permission.

Tests:
- Add unit tests for the WalkingDetector cadence classifier to distinguish steady walking from insufficient, irregular, or too-slow step patterns.